### PR TITLE
Fix to properly decode Unicode in Android

### DIFF
--- a/ProjNet/IO/CoordinateSystems/StreamTokenizer.cs
+++ b/ProjNet/IO/CoordinateSystems/StreamTokenizer.cs
@@ -191,7 +191,17 @@ namespace ProjNet.Converters.WellKnownText.IO
 				// convert int to char
 				ba = new Byte[]{(byte)_reader.Peek()};
 				
-				 ascii = AE.GetChars(ba);
+				// ascii = AE.GetChars(ba);
+
+                if (AE.GetByteCount("a") == 2)
+                {
+                    // handle unicode appropriately
+                    ascii = AE.GetChars(new byte[2] { ba[0], 0 });
+                }
+                else
+                {
+                    ascii = AE.GetChars(ba);
+                }
 
 				currentCharacter = chars[0];
 				nextCharacter = ascii[0];


### PR DESCRIPTION
I was unable to properly read wkt files on Android. The fix was to check if text actually come in pair of bytes.
I found this on codeplex, but I don't think it ever went into the main codebase.

To successfully read the wkt file to a string in Android I had to do this

```
var wktProj = File.ReadAllText(Path.ChangeExtension(shapeFileName, "prj"), Encoding.UTF8);
```

Using Unicode here produced wrong results.

Then 

```
   var pcs = CoordinateSystemWktReader.Parse(ww) as ICoordinateSystem;
```

to get the project would fail.
