### PR TITLE
New AffineTransform class and WKT parsing of IFittedCoordinateSystem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,4 @@ UpgradeLog*.htm
 # Microsoft Fakes
 FakesAssemblies/
 /packages
+/ProjNET.Pcl/IO/CoordinateSystems/MathTransformWktReader.cs

--- a/ProjNET.Pcl/ProjNET.Pcl.csproj
+++ b/ProjNET.Pcl/ProjNET.Pcl.csproj
@@ -74,6 +74,9 @@
     <Compile Include="..\ProjNet\CoordinateSystems\HorizontalDatum.cs">
       <Link>CoordinateSystems\HorizontalDatum.cs</Link>
     </Compile>
+    <Compile Include="..\ProjNet\CoordinateSystems\ParameterInfo.cs">
+      <Link>CoordinateSystems\ParameterInfo.cs</Link>
+    </Compile>
     <Compile Include="..\ProjNet\CoordinateSystems\Info.cs">
       <Link>CoordinateSystems\Info.cs</Link>
     </Compile>
@@ -128,6 +131,9 @@
     <Compile Include="..\ProjNet\CoordinateSystems\Projections\TransverseMercator.cs">
       <Link>CoordinateSystems\Projections\TransverseMercator.cs</Link>
     </Compile>
+    <Compile Include="..\ProjNet\CoordinateSystems\Transformations\AffineTransform.cs">
+      <Link>CoordinateSystems\Transformations\AffineTransform.cs</Link>
+    </Compile>
     <Compile Include="..\ProjNet\CoordinateSystems\Transformations\ConcatenatedTransform.cs">
       <Link>CoordinateSystems\Transformations\ConcatenatedTransform.cs</Link>
     </Compile>
@@ -157,6 +163,9 @@
     </Compile>
     <Compile Include="..\ProjNet\IO\CoordinateSystems\CoordinateSystemWktReader.cs">
       <Link>IO\CoordinateSystems\CoordinateSystemWktReader.cs</Link>
+    </Compile>
+    <Compile Include="..\ProjNet\IO\CoordinateSystems\MathTransformWktReader.cs">
+      <Link>IO\CoordinateSystems\MathTransformWktReader.cs</Link>
     </Compile>
     <Compile Include="..\ProjNet\IO\CoordinateSystems\StreamTokenizer.cs">
       <Link>IO\CoordinateSystems\StreamTokenizer.cs</Link>

--- a/ProjNet.Tests/CoordinateTransformTests.cs
+++ b/ProjNet.Tests/CoordinateTransformTests.cs
@@ -595,5 +595,131 @@ namespace ProjNet.UnitTests
             Assert.AreNotEqual(290586.087, transformedCoords[0][0]);
             Assert.AreNotEqual(6714000, transformedCoords[0][1]);
         }
+
+        /// <summary>
+        /// Test transformation for affine transformation
+        /// </summary>
+        [Test]
+        public void AffineTransformationTest ()
+        {
+            //Local coordinate system MNAU (Kraftwerk Mäuserich) (based on Gauß-Krüger using affine transformation)
+            // affine transform
+            // 1) Offset: X=-3454886,640m Y=-5479481,278m;
+            // 2)Rotation: 332,0657, Rotation point  X=3456926,640m Y=5481071,278m;
+            // 3) Scale: 1.0
+
+            //TODO MathTransformFactory fac = new MathTransformFactory ();
+            double[,] matrix = new double[,] {{0.883485346527455, -0.468458794848877, 3455869.17937689}, 
+                                              {0.468458794848877, 0.883485346527455, 5478710.88035753},
+                                              {0.0 , 0.0, 1},};
+            IMathTransform mt = new AffineTransform (matrix);
+
+            Assert.IsNotNull (mt);
+
+            Assert.AreEqual (2, mt.DimSource);
+            Assert.AreEqual (2, mt.DimTarget);
+
+            //Transformation example (MNAU -> GK)
+            // Start point (MNAU) X=2040,000m Y=1590,000m]
+            // Target point (GK): X=3456926,640m Y=5481071,278m;
+
+            double[] outPt = mt.Transform (new double[] { 2040.0, 1590.0 });
+
+            Assert.AreEqual (2, outPt.Length);
+            Assert.AreEqual (3456926.640, outPt[0], 0.00000001);
+            Assert.AreEqual (5481071.278, outPt[1], 0.00000001);
+        }
+
+        /// <summary>
+        /// Test inverse transformation for affine transformation
+        /// </summary>
+        [Test]
+        public void InverseAffineTransformationTest ()
+        {
+            //Local coordinate system MNAU (Kraftwerk Mäuserich) (based on Gauß-Krüger using affine transformation)
+            // affine transform
+            // 1) Offset: X=-3454886,640m Y=-5479481,278m;
+            // 2)Rotation: 332,0657, Rotation point  X=3456926,640m Y=5481071,278m;
+            // 3) Scale: 1.0
+
+            //TODO MathTransformFactory fac = new MathTransformFactory ();
+            double[,] matrix = new double[,] {{0.883485346527455, -0.468458794848877, 3455869.17937689}, 
+                                              {0.468458794848877, 0.883485346527455, 5478710.88035753},
+                                              {0.0 , 0.0, 1},};
+            IMathTransform mt = new AffineTransform (matrix);
+
+            Assert.IsNotNull (mt);
+
+            Assert.AreEqual (2, mt.DimSource);
+            Assert.AreEqual (2, mt.DimTarget);
+
+            //Transformation example (MNAU -> GK)
+            // Start point (MNAU) X=2040,000m Y=1590,000m]
+            // Target point (GK): X=3456926,640m Y=5481071,278m;
+
+            IMathTransform invMt = mt.Inverse ();
+
+            double[] inPt = invMt.Transform (new double[] { 3456926.640, 5481071.278 });
+
+            Assert.AreEqual (2, inPt.Length);
+            Assert.AreEqual (2040.0, inPt[0], 0.00000001);
+            Assert.AreEqual (1590.0, inPt[1], 0.00000001);
+        }
+
+        /// <summary>
+        /// Coordinate transformation test for fitted coordinate system - test CS - local coordinate system MNAU
+        /// </summary>
+        [Test]
+        public void TestTransformOnFittedCoordinateSystem ()
+        {
+
+            //Local coordinate system MNAU (Kraftwerk Mäuserich) (based on Gauß-Krüger using affine transformation)
+            // affine transform
+            // 1) Offset: X=-3454886,640m Y=-5479481,278m;
+            // 2)Rotation: 332,0657, Rotation point  X=3456926,640m Y=5481071,278m;
+            // 3) Scale: 1.0
+
+            string ft_wkt = "FITTED_CS[\"Local coordinate system MNAU (based on Gauss-Krueger)\"," +
+                                "PARAM_MT[\"Affine\"," +
+                                   "PARAMETER[\"num_row\",3],PARAMETER[\"num_col\",3],PARAMETER[\"elt_0_0\", 0.883485346527455],PARAMETER[\"elt_0_1\", -0.468458794848877],PARAMETER[\"elt_0_2\", 3455869.17937689],PARAMETER[\"elt_1_0\", 0.468458794848877],PARAMETER[\"elt_1_1\", 0.883485346527455],PARAMETER[\"elt_1_2\", 5478710.88035753],PARAMETER[\"elt_2_2\", 1]]," +
+                                "PROJCS[\"DHDN / Gauss-Kruger zone 3\"," +
+                                   "GEOGCS[\"DHDN\"," +
+                                      "DATUM[\"Deutsches_Hauptdreiecksnetz\"," +
+                                         "SPHEROID[\"Bessel 1841\", 6377397.155, 299.1528128, AUTHORITY[\"EPSG\", \"7004\"]]," +
+                                         "TOWGS84[612.4, 77, 440.2, -0.054, 0.057, -2.797, 0.525975255930096]," +
+                                         "AUTHORITY[\"EPSG\", \"6314\"]]," +
+                                       "PRIMEM[\"Greenwich\", 0, AUTHORITY[\"EPSG\", \"8901\"]]," +
+                                       "UNIT[\"degree\", 0.0174532925199433, AUTHORITY[\"EPSG\", \"9122\"]]," +
+                                       "AUTHORITY[\"EPSG\", \"4314\"]]," +
+                                   "UNIT[\"metre\", 1, AUTHORITY[\"EPSG\", \"9001\"]]," +
+                                   "PROJECTION[\"Transverse_Mercator\"]," +
+                                   "PARAMETER[\"latitude_of_origin\", 0]," +
+                                   "PARAMETER[\"central_meridian\", 9]," +
+                                   "PARAMETER[\"scale_factor\", 1]," +
+                                   "PARAMETER[\"false_easting\", 3500000]," +
+                                   "PARAMETER[\"false_northing\", 0]," +
+                                   "AUTHORITY[\"EPSG\", \"31467\"]]" +
+                        "]";
+
+            //string gk_wkt = "PROJCS[\"DHDN / Gauss-Kruger zone 3\",GEOGCS[\"DHDN\",DATUM[\"Deutsches_Hauptdreiecksnetz\",SPHEROID[\"Bessel 1841\",6377397.155,299.1528128,AUTHORITY[\"EPSG\",\"7004\"]],AUTHORITY[\"EPSG\",\"6314\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4314\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",1],PARAMETER[\"false_easting\",3500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AUTHORITY[\"EPSG\",\"31467\"]]";
+
+            CoordinateSystemFactory fac = new CoordinateSystemFactory ();
+            IFittedCoordinateSystem fcs = fac.CreateFromWkt (ft_wkt) as IFittedCoordinateSystem;
+            //ICoordinateSystem gkcs = fac.CreateFromWkt (gk_wkt);
+
+            //Transformation example (MNAU -> GK)
+            // Start point (MNAU) X=2040,000m Y=1590,000m]
+            // Target point (GK): X=3456926,640m Y=5481071,278m;
+
+            ICoordinateTransformation trans = CoordinateTransformationFactory.CreateFromCoordinateSystems (fcs, fcs.BaseCoordinateSystem);
+
+            List<double[]> coords = new List<double[]>{
+                new double[]{2040.0, 1590.0},
+            };
+
+            IList<double[]> transformedCoords = trans.MathTransform.TransformList (coords);
+            Assert.AreEqual (3456926.640, transformedCoords[0][0], 0.00000001);
+            Assert.AreEqual (5481071.278, transformedCoords[0][1], 0.00000001);
+        }
     }
 }

--- a/ProjNet.Tests/ProjNET.Tests.csproj
+++ b/ProjNet.Tests/ProjNET.Tests.csproj
@@ -101,6 +101,7 @@
     </Compile>
     <Compile Include="WKT\PostGisSpatialRefSysTableParserTest.cs" />
     <Compile Include="WKT\WKTCoordSysParserTests.cs" />
+    <Compile Include="WKT\WKTMathTransformParserTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ProjNet\ProjNET.csproj">
@@ -148,6 +149,9 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <SubType>Designer</SubType>
     </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />

--- a/ProjNet.Tests/ProjNetIssues.cs
+++ b/ProjNet.Tests/ProjNetIssues.cs
@@ -192,5 +192,38 @@ namespace ProjNet.UnitTests
             IMathTransform inverse = mathTransform.Inverse();
             Assert.That(inverse, Is.Not.Null);
         }
+
+        /// <summary>
+        /// Wrong AngularUnits.EqualParams implementation
+        /// </summary>
+        [Test]
+        public void TestAngularUnitsEqualParamsIssue()
+        {
+            //string sourceWkt = " UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]";
+
+            string wkt = "PROJCS[\"DHDN / Gauss-Kruger zone 3\",GEOGCS[\"DHDN\",DATUM[\"Deutsches_Hauptdreiecksnetz\",SPHEROID[\"Bessel 1841\",6377397.155,299.1528128,AUTHORITY[\"EPSG\",\"7004\"]],AUTHORITY[\"EPSG\",\"6314\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4314\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",1],PARAMETER[\"false_easting\",3500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AUTHORITY[\"EPSG\",\"31467\"]]";
+
+            CoordinateSystemFactory csf = new CoordinateSystems.CoordinateSystemFactory ();
+
+            IProjectedCoordinateSystem pcs1 = csf.CreateFromWkt (wkt) as IProjectedCoordinateSystem;
+
+            Assert.NotNull (pcs1);
+            Assert.NotNull (pcs1.GeographicCoordinateSystem);
+            Assert.NotNull (pcs1.GeographicCoordinateSystem.AngularUnit);
+
+            string savedWkt = pcs1.WKT;
+            IProjectedCoordinateSystem pcs2 = csf.CreateFromWkt (savedWkt) as IProjectedCoordinateSystem;
+
+            //test AngularUnit parsing via ProjectedCoordinateSystem
+            Assert.NotNull (pcs2);
+            Assert.NotNull (pcs2.GeographicCoordinateSystem);
+            Assert.NotNull (pcs2.GeographicCoordinateSystem.AngularUnit);
+
+            //check equality of angular units via RadiansPerUnit
+            Assert.AreEqual (pcs1.GeographicCoordinateSystem.AngularUnit.RadiansPerUnit, pcs2.GeographicCoordinateSystem.AngularUnit.RadiansPerUnit, 0.0000000000001);
+            //check equality of angular units
+            Assert.AreEqual (true, pcs1.GeographicCoordinateSystem.AngularUnit.EqualParams (pcs2.GeographicCoordinateSystem.AngularUnit));
+        }
+      
     }
 }

--- a/ProjNet.Tests/WKT/WKTCoordSysParserTests.cs
+++ b/ProjNet.Tests/WKT/WKTCoordSysParserTests.cs
@@ -269,5 +269,56 @@ namespace ProjNet.UnitTests.Converters.WKT
             Assert.AreEqual(wkt, newWkt);
 
         }
+
+        /// <summary>
+        /// Test parsing of IFittedCoordinate system from WKT
+        /// </summary>
+        [Test]
+        public void ParseFittedCoordinateSystemWkt ()
+        {
+            CoordinateSystemFactory fac = new CoordinateSystemFactory ();
+            IFittedCoordinateSystem fcs = null;
+            string wkt = "FITTED_CS[\"Local coordinate system MNAU (based on Gauss-Krueger)\"," + 
+                                "PARAM_MT[\"Affine\"," + 
+                                   "PARAMETER[\"num_row\",3],PARAMETER[\"num_col\",3],PARAMETER[\"elt_0_0\", 0.883485346527455],PARAMETER[\"elt_0_1\", -0.468458794848877],PARAMETER[\"elt_0_2\", 3455869.17937689],PARAMETER[\"elt_1_0\", 0.468458794848877],PARAMETER[\"elt_1_1\", 0.883485346527455],PARAMETER[\"elt_1_2\", 5478710.88035753],PARAMETER[\"elt_2_2\", 1]]," + 
+                                "PROJCS[\"DHDN / Gauss-Kruger zone 3\"," +
+                                   "GEOGCS[\"DHDN\"," + 
+                                      "DATUM[\"Deutsches_Hauptdreiecksnetz\"," + 
+                                         "SPHEROID[\"Bessel 1841\", 6377397.155, 299.1528128, AUTHORITY[\"EPSG\", \"7004\"]]," + 
+                                         "TOWGS84[612.4, 77, 440.2, -0.054, 0.057, -2.797, 0.525975255930096]," + 
+                                         "AUTHORITY[\"EPSG\", \"6314\"]]," + 
+                                       "PRIMEM[\"Greenwich\", 0, AUTHORITY[\"EPSG\", \"8901\"]]," + 
+                                       "UNIT[\"degree\", 0.0174532925199433, AUTHORITY[\"EPSG\", \"9122\"]]," + 
+                                       "AUTHORITY[\"EPSG\", \"4314\"]]," + 
+                                   "UNIT[\"metre\", 1, AUTHORITY[\"EPSG\", \"9001\"]]," + 
+                                   "PROJECTION[\"Transverse_Mercator\"]," + 
+                                   "PARAMETER[\"latitude_of_origin\", 0]," + 
+                                   "PARAMETER[\"central_meridian\", 9]," + 
+                                   "PARAMETER[\"scale_factor\", 1]," + 
+                                   "PARAMETER[\"false_easting\", 3500000]," +
+                                   "PARAMETER[\"false_northing\", 0]," + 
+                                   "AUTHORITY[\"EPSG\", \"31467\"]]" + 
+                        "]";
+
+            try
+            { 
+                fcs = fac.CreateFromWkt (wkt) as IFittedCoordinateSystem;
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail ("Could not create fitted coordinate system from:\r\n" + wkt + "\r\n" + ex.Message);
+            }
+
+            Assert.IsNotNull (fcs);
+            Assert.IsNotNullOrEmpty (fcs.ToBase ());
+            Assert.IsNotNull (fcs.BaseCoordinateSystem);
+
+            Assert.AreEqual ("Local coordinate system MNAU (based on Gauss-Krueger)", fcs.Name);
+            //Assert.AreEqual ("CUSTOM", fcs.Authority);
+            //Assert.AreEqual (123456, fcs.AuthorityCode);
+
+            Assert.AreEqual ("EPSG", fcs.BaseCoordinateSystem.Authority);
+            Assert.AreEqual (31467, fcs.BaseCoordinateSystem.AuthorityCode);
+        }
     }
 }

--- a/ProjNet.Tests/WKT/WKTMathTransformParserTests.cs
+++ b/ProjNet.Tests/WKT/WKTMathTransformParserTests.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.IO;
+using GeoAPI.CoordinateSystems;
+using GeoAPI.CoordinateSystems.Transformations;
+using NUnit.Framework;
+using ProjNet.CoordinateSystems;
+using ProjNet.CoordinateSystems.Transformations;
+using ProjNet.Converters.WellKnownText;
+
+namespace ProjNet.UnitTests.Converters.WKT
+{
+    [TestFixture]
+    public class WKTMathTransformParserTests
+    {
+        /// <summary>
+        /// Test parsing of affine math transform from WKT
+        /// </summary>
+        [Test]
+        public void ParseAffineTransformWkt ()
+        {
+            //TODO MathTransformFactory fac = new MathTransformFactory ();
+            IMathTransform mt = null;
+            string wkt = "PARAM_MT[\"Affine\"," +
+                            "PARAMETER[\"num_row\",3]," +
+                            "PARAMETER[\"num_col\",3]," +
+                            "PARAMETER[\"elt_0_0\", 0.883485346527455]," +
+                            "PARAMETER[\"elt_0_1\", -0.468458794848877]," +
+                            "PARAMETER[\"elt_0_2\", 3455869.17937689]," +
+                            "PARAMETER[\"elt_1_0\", 0.468458794848877]," +
+                            "PARAMETER[\"elt_1_1\", 0.883485346527455]," +
+                            "PARAMETER[\"elt_1_2\", 5478710.88035753]," +
+                            "PARAMETER[\"elt_2_2\", 1]]";
+
+            try
+            {
+                //TODO replace with MathTransformFactory implementation
+                mt = MathTransformWktReader.Parse (wkt, System.Text.Encoding.Unicode);
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail ("Could not create affine math transformation from:\r\n" + wkt + "\r\n" + ex.Message);
+            }
+
+            Assert.IsNotNull (mt);
+            Assert.IsNotNull (mt as AffineTransform);
+
+            Assert.AreEqual (2, mt.DimSource);
+            Assert.AreEqual (2, mt.DimTarget);
+
+            //test simple transform
+            double[] outPt = mt.Transform (new double[] { 0.0, 0.0 });
+
+            Assert.AreEqual (2, outPt.Length);
+            Assert.AreEqual (3455869.17937689, outPt[0], 0.00000001);
+            Assert.AreEqual (5478710.88035753, outPt[1], 0.00000001);
+        }
+    }
+}

--- a/ProjNet/CoordinateSystems/ParameterInfo.cs
+++ b/ProjNet/CoordinateSystems/ParameterInfo.cs
@@ -18,8 +18,6 @@
 using GeoAPI.CoordinateSystems;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace ProjNet.CoordinateSystems
 {
@@ -50,7 +48,7 @@ namespace ProjNet.CoordinateSystems
         /// <summary>
         /// Gets or sets the parameters set for this projection.
         /// </summary>
-        public List<Parameter> Parameters
+        public List<GeoAPI.CoordinateSystems.Parameter> Parameters
         { 
             get;
             set;
@@ -60,9 +58,9 @@ namespace ProjNet.CoordinateSystems
         /// Returns the default parameters for this projection.
         /// </summary>
         /// <returns></returns>
-        public Parameter[] DefaultParameters ()
+        public GeoAPI.CoordinateSystems.Parameter[] DefaultParameters ()
         {
-            return new Parameter[0];
+            return new GeoAPI.CoordinateSystems.Parameter[0];
         }
 
         /// <summary>
@@ -70,12 +68,12 @@ namespace ProjNet.CoordinateSystems
         /// </summary>
         /// <param name="name"></param>
         /// <returns></returns>
-        public Parameter GetParameterByName (string name)
+        public GeoAPI.CoordinateSystems.Parameter GetParameterByName (string name)
         {
             if (this.Parameters != null)
             {
                 //search parameter collection by name 
-                foreach (Parameter param in this.Parameters)
+                foreach (GeoAPI.CoordinateSystems.Parameter param in this.Parameters)
                 {
                     if (param != null && param.Name == name)
                     {

--- a/ProjNet/CoordinateSystems/ParameterInfo.cs
+++ b/ProjNet/CoordinateSystems/ParameterInfo.cs
@@ -1,0 +1,90 @@
+﻿// Copyright 2005 - 2009 - Morten Nielsen (www.sharpgis.net)
+//
+// This file is part of ProjNet.
+// ProjNet is free software; you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+// 
+// ProjNet is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public License
+// along with ProjNet; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA 
+
+using GeoAPI.CoordinateSystems;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ProjNet.CoordinateSystems
+{
+    /// <summary>
+    /// Simple class that implements the IParameterInfo interface for providing general set of the parameters.
+    /// It allows discovering the names, and for setting and getting parameter values.
+    /// </summary>
+#if !PCL
+    [Serializable]
+#endif
+    internal class ParameterInfo : IParameterInfo
+    {
+        /// <summary>
+        /// Gets the number of parameters expected.
+        /// </summary>
+        public int NumParameters
+        { 
+            get
+            {
+                if (this.Parameters != null)
+                {
+                    return this.Parameters.Count;
+                }
+                return 0;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the parameters set for this projection.
+        /// </summary>
+        public List<Parameter> Parameters
+        { 
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Returns the default parameters for this projection.
+        /// </summary>
+        /// <returns></returns>
+        public Parameter[] DefaultParameters ()
+        {
+            return new Parameter[0];
+        }
+
+        /// <summary>
+        /// Gets the parameter by its name
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        public Parameter GetParameterByName (string name)
+        {
+            if (this.Parameters != null)
+            {
+                //search parameter collection by name 
+                foreach (Parameter param in this.Parameters)
+                {
+                    if (param != null && param.Name == name)
+                    {
+                        return param;
+                    }
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/ProjNet/CoordinateSystems/Transformations/AffineTransform.cs
+++ b/ProjNet/CoordinateSystems/Transformations/AffineTransform.cs
@@ -203,9 +203,9 @@ namespace ProjNet.CoordinateSystems.Transformations
         /// <param name="pi"></param>
         /// <param name="b"></param>
         /// <returns></returns>
-        private static double[] LUPSolve (double[][] LU, int[] pi, double[] b)
+        private static double[] LUPSolve (double[,] LU, int[] pi, double[] b)
         {
-            int n = LU.Length - 1;
+            int n = LU.GetLength (0) - 1;
             double[] x = new double[n + 1];
             double[] y = new double[n + 1];
             double suml = 0;
@@ -231,7 +231,7 @@ namespace ProjNet.CoordinateSystems.Transformations
                     }
                     else
                     {
-                        lij = LU[i][j];
+                        lij = LU[i, j];
                     }
                     suml = suml + (lij * y[j]);
                 }
@@ -243,22 +243,12 @@ namespace ProjNet.CoordinateSystems.Transformations
                 sumu = 0;
                 for (int j = i + 1; j <= n; j++)
                 {
-                    sumu = sumu + (LU[i][j] * x[j]);
+                    sumu = sumu + (LU[i, j] * x[j]);
                 }
-                x[i] = (y[i] - sumu) / LU[i][i];
+                x[i] = (y[i] - sumu) / LU[i, i];
             }
             return x;
         }
-
-        /*
-        * Perform LUP decomposition on a matrix A.
-        * Return L and U as a single matrix(double[][]) and P as an array of ints.
-        * We implement the code to compute LU "in place" in the matrix A.
-        * In order to make some of the calculations more straight forward and to 
-        * match Cormen's et al. pseudocode the matrix A should have its first row and first columns
-        * to be all 0.
-        * */
-
 
         /// <summary>
         /// Perform LUP decomposition on a matrix A.
@@ -271,9 +261,9 @@ namespace ProjNet.CoordinateSystems.Transformations
         /// <seealso href="http://www.rkinteractive.com/blogs/SoftwareDevelopment/post/2013/05/07/Algorithms-In-C-LUP-Decomposition.aspx"/>
         /// <param name="A"></param>
         /// <returns></returns>
-        private static Tuple<double[][], int[]> LUPDecomposition (double[][] A)
+        private static Tuple<double[,], int[]> LUPDecomposition (double[,] A)
         {
-            int n = A.Length - 1;
+            int n = A.GetLength (0) - 1;
             /*
             * pi represents the permutation matrix.  We implement it as an array
             * whose value indicates which column the 1 would appear.  We use it to avoid 
@@ -306,9 +296,9 @@ namespace ProjNet.CoordinateSystems.Transformations
                 p = 0;
                 for (int i = k; i <= n; i++)
                 {
-                    if (Math.Abs (A[i][k]) > p)
+                    if (Math.Abs (A[i, k]) > p)
                     {
-                        p = Math.Abs (A[i][k]);
+                        p = Math.Abs (A[i, k]);
                         kp = i;
                     }
                 }
@@ -330,10 +320,10 @@ namespace ProjNet.CoordinateSystems.Transformations
                 * */
                 for (int i = 0; i <= n; i++)
                 {
-                    aki = A[k][i];
-                    akpi = A[kp][i];
-                    A[k][i] = akpi;
-                    A[kp][i] = aki;
+                    aki = A[k, i];
+                    akpi = A[kp, i];
+                    A[k, i] = akpi;
+                    A[kp, i] = aki;
                 }
 
                 /*
@@ -341,10 +331,10 @@ namespace ProjNet.CoordinateSystems.Transformations
                     * */
                 for (int i = k + 1; i <= n; i++)
                 {
-                    A[i][k] = A[i][k] / A[k][k];
+                    A[i, k] = A[i, k] / A[k, k];
                     for (int j = k + 1; j <= n; j++)
                     {
-                        A[i][j] = A[i][j] - (A[i][k] * A[k][j]);
+                        A[i, j] = A[i, j] - (A[i, k] * A[k, j]);
                     }
                 }
             }
@@ -358,17 +348,14 @@ namespace ProjNet.CoordinateSystems.Transformations
         /// <seealso href="http://www.rkinteractive.com/blogs/SoftwareDevelopment/post/2013/05/21/Algorithms-In-C-Finding-The-Inverse-Of-A-Matrix.aspx"/>
         /// <param name="A"></param>
         /// <returns></returns>
-        private static double[][] InvertMatrix (double[][] A)
+        private static double[,] InvertMatrix (double[,] A)
         {
-            int n = A.Length;
-            //e will represent each column in the identity matrix
-            double[] e;
+            int n = A.GetLength (0);
+            int m = A.GetLength (1);
+
             //x will hold the inverse matrix to be returned
-            double[][] x = new double[n][];
-            for (int i = 0; i < n; i++)
-            {
-                x[i] = new double[A[i].Length];
-            }
+            double[,] x = new double[n, m];
+
             /*
             * solve will contain the vector solution for the LUP decomposition as we solve
             * for each vector of x.  We will combine the solutions into the double[][] array x.
@@ -376,9 +363,9 @@ namespace ProjNet.CoordinateSystems.Transformations
             double[] solve;
 
             //Get the LU matrix and P matrix (as an array)
-            Tuple<double[][], int[]> results = LUPDecomposition (A);
+            Tuple<double[,], int[]> results = LUPDecomposition (A);
 
-            double[][] LU = results.Item1;
+            double[,] LU = results.Item1;
             int[] P = results.Item2;
 
             /*
@@ -386,12 +373,13 @@ namespace ProjNet.CoordinateSystems.Transformations
             * */
             for (int i = 0; i < n; i++)
             {
-                e = new double[A[i].Length];
+                //e will represent each column in the identity matrix
+                double[] e = new double[m];
                 e[i] = 1;
                 solve = LUPSolve (LU, P, e);
                 for (int j = 0; j < solve.Length; j++)
                 {
-                    x[j][i] = solve[j];
+                    x[j, i] = solve[j];
                 }
             }
             return x;
@@ -407,28 +395,10 @@ namespace ProjNet.CoordinateSystems.Transformations
         {
             if (_inverse == null)
             {
-                //if input dimension is M, and output dimension is N, then the matrix will have size [N+1][M+1].
-                double[][] srcMatrix = new double[dimTarget + 1][];
-                for (int row = 0; row <= dimTarget; row++)
-                {
-                    srcMatrix[row] = new double[dimSource + 1];
-                    for (int col = 0; col <= dimSource; col++)
-                    {
-                        srcMatrix[row][col] = transformMatrix[row, col];
-                    }
-                }
-                var invMatrix = InvertMatrix (srcMatrix);
-                //fill instance of inverted matrix for affine transform
-                double[,] matrix = new double[dimSource + 1, dimTarget + 1];
-                for (int i = 0; i <= dimSource; i++)
-                {
-                    for (int j = 0; j <= dimTarget; j++)
-                    {
-                        matrix[i, j] = invMatrix[i][j];
-                    }
-                }
-
-                _inverse = new AffineTransform (matrix);
+                //find the inverse transformation matrix
+                //remarks about dimensionality: if input dimension is M, and output dimension is N, then the matrix will have size [N+1][M+1].
+                var invMatrix = InvertMatrix (transformMatrix);
+                _inverse = new AffineTransform (invMatrix);
             }
 
             return _inverse;

--- a/ProjNet/CoordinateSystems/Transformations/AffineTransform.cs
+++ b/ProjNet/CoordinateSystems/Transformations/AffineTransform.cs
@@ -1,0 +1,487 @@
+﻿// Copyright 2005 - 2009 - Morten Nielsen (www.sharpgis.net)
+//
+// This file is part of ProjNet.
+// ProjNet is free software; you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+// 
+// ProjNet is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public License
+// along with ProjNet; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA 
+
+using GeoAPI.CoordinateSystems;
+using GeoAPI.CoordinateSystems.Transformations;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace ProjNet.CoordinateSystems.Transformations
+{
+
+    /// <summary>
+    /// Represents affine math transform which ttransform input coordinates to target using affine transformation matrix. Dimensionality might change.
+    /// </summary>
+    ///<remarks>If the transform's input dimension is M, and output dimension is N, then the matrix will have size [N+1][M+1].
+    ///The +1 in the matrix dimensions allows the matrix to do a shift, as well as a rotation.
+    ///The [M][j] element of the matrix will be the j'th ordinate of the moved origin.
+    ///The [i][N] element of the matrix will be 0 for i less than M, and 1 for i equals M.</remarks>
+    /// <seealso href="http://en.wikipedia.org/wiki/Affine_transformation"/>
+#if !PCL
+    [Serializable]
+#endif
+    public class AffineTransform : MathTransform
+    {
+        #region class variables
+        /// <summary>
+        /// Saved inverse transform
+        /// </summary>
+        private IMathTransform _inverse;
+
+        /// <summary>
+        /// Dimension of source points - it's related to number of transformation matrix rows
+        /// </summary>
+        private readonly int dimSource;
+
+        /// <summary>
+        /// Dimension of output points - it's related to number of columns
+        /// </summary>
+        private readonly int dimTarget;
+
+        /// <summary>
+        /// Represents transform matrix of this affine transformation from input points to output ones using dimensionality defined within the affine transform
+        /// Number of rows = dimTarget + 1
+        /// Number of columns = dimSource + 1
+        /// </summary>
+        private readonly double[,] transformMatrix;
+        #endregion class variables
+
+        #region constructors & finalizers
+        /// <summary>
+        /// Creates instance of 2D affine transform (source dimensionality 2, target dimensionality 2) using the specified values
+        /// </summary>
+        /// <param name="m00">Value for row 0, column 0 - AKA ScaleX</param>
+        /// <param name="m01">Value for row 0, column 1 - AKA ShearX</param>
+        /// <param name="m02">Value for row 0, column 2 - AKA Translate X</param>
+        /// <param name="m10">Value for row 1, column 0 - AKA Shear Y</param>
+        /// <param name="m11">Value for row 1, column 1 - AKA Scale Y</param>
+        /// <param name="m12">Value for row 1, column 2 - AKA Translate Y</param>
+        public AffineTransform (double m00, double m01, double m02, double m10, double m11, double m12)
+            : base ()
+        {
+            //fill dimensionlity
+            dimSource = 2;
+            dimTarget = 2;
+            //create matrix - 2D affine transform uses 3x3 matrix (3rd row is the special one)
+            transformMatrix = new double[3, 3] {{m00, m01, m02}, {m10, m11, m12}, {0, 0, 1}};
+        }
+
+        /// <summary>
+        /// Creates instance of affine transform using the specified matrix. 
+        /// </summary>
+        /// <remarks>If the transform's input dimension is M, and output dimension is N, then the matrix will have size [N+1][M+1].
+        /// The +1 in the matrix dimensions allows the matrix to do a shift, as well as a rotation. The [M][j] element of the matrix will be the j'th ordinate of the moved origin. The [i][N] element of the matrix will be 0 for i less than M, and 1 for i equals M.</remarks>
+        ///
+        /// <param name="matrix">Matrix used to create afiine transform</param>
+        public AffineTransform (double[,] matrix)
+            : base ()
+        {
+            //check validity
+            if (matrix == null)
+            {
+                throw new ArgumentNullException ("matrix");
+            }
+            if (matrix.GetLength (0) <= 1)
+            {
+                throw new ArgumentException ("Transformation matrix must have at least 2 rows.");
+            }
+            if (matrix.GetLength (1) <= 1)
+            {
+                throw new ArgumentException ("Transformation matrix must have at least 2 columns.");
+            }
+
+            //fill dimensionlity - dimension is M, and output dimension is N, then the matrix will have size [N+1][M+1].
+            dimSource = matrix.GetLength (1) - 1;
+            dimTarget = matrix.GetLength (0) - 1;
+            //use specified matrix
+            transformMatrix = matrix;
+        }
+        #endregion constructors & finalizers
+
+        #region public properties
+        /// <summary>
+        /// Gets a Well-Known text representation of this affine math transformation.
+        /// </summary>
+        /// <value></value>
+        public override string WKT
+        {
+            get
+            {
+                //PARAM_MT["Affine",
+                //    PARAMETER["num_row",3],
+                //    PARAMETER["num_col",3],
+                //    PARAMETER["elt_0_1",1],
+                //    PARAMETER["elt_0_2",2],
+                //    PARAMETER["elt 1 2",3]]
+
+                var sb = new StringBuilder ();
+
+                sb.Append ("PARAM_MT[\"Affine\"");
+                //append parameters
+                foreach (ProjectionParameter param in this.GetParameterValues ())
+                {
+                    sb.Append (",");
+                    sb.Append (param.WKT);
+                }
+                sb.Append ("]");
+                return sb.ToString ();
+            }
+        }
+        /// <summary>
+        /// Gets an XML representation of this affine transformation.
+        /// </summary>
+        /// <value></value>
+        public override string XML
+        {
+            get { throw new NotImplementedException ("The method or operation is not implemented."); }
+        }
+
+        /// <summary>
+        /// Gets the dimension of input points.
+        /// </summary>
+        public override int DimSource { get { return dimSource; } }
+
+        /// <summary>
+        /// Gets the dimension of output points.
+        /// </summary>
+        public override int DimTarget { get { return dimTarget; } }
+        #endregion public properties
+
+        #region private methods
+
+        /// <summary>
+        /// Return affine transformation matrix as group of parameter values that maiy be used for retrieving WKT of this affine transform
+        /// </summary>
+        /// <returns>List of string pairs NAME VALUE</returns>
+        private IList<ProjectionParameter> GetParameterValues () 
+        {
+            int rowCnt =transformMatrix.GetLength (0);
+            int colCnt =transformMatrix.GetLength (1);
+            var pInfo = new List<ProjectionParameter> ();
+            pInfo.Add (new ProjectionParameter ("num_row", rowCnt));
+            pInfo.Add (new ProjectionParameter ("num_col", colCnt));
+            //fill matrix values
+            for (int row = 0; row < rowCnt; row++)
+            {
+                for (int col = 0; col < colCnt; col++)
+                {
+                    string name = string.Format (CultureInfo.InvariantCulture.NumberFormat, "elt_{0}_{1}", row, col);
+                    pInfo.Add (new ProjectionParameter (name, transformMatrix[row, col]));
+                }
+            }
+            return pInfo;
+        }
+
+
+        /// <summary>
+        /// Given L,U,P and b solve for x.
+        /// Input the L and U matrices as a single matrix LU.
+        /// Return the solution as a double[].
+        /// LU will be a n+1xm+1 matrix where the first row and columns are zero.
+        /// This is for ease of computation and consistency with Cormen et al.
+        /// pseudocode.
+        /// The pi array represents the permutation matrix.
+        /// </summary>
+        /// <seealso href="http://www.rkinteractive.com/blogs/SoftwareDevelopment/post/2013/05/14/Algorithms-In-C-Solving-A-System-Of-Linear-Equations.aspx"/>
+        /// <param name="LU"></param>
+        /// <param name="pi"></param>
+        /// <param name="b"></param>
+        /// <returns></returns>
+        private static double[] LUPSolve (double[][] LU, int[] pi, double[] b)
+        {
+            int n = LU.Length - 1;
+            double[] x = new double[n + 1];
+            double[] y = new double[n + 1];
+            double suml = 0;
+            double sumu = 0;
+            double lij = 0;
+
+            /*
+            * Solve for y using formward substitution
+            * */
+            for (int i = 0; i <= n; i++)
+            {
+                suml = 0;
+                for (int j = 0; j <= i - 1; j++)
+                {
+                    /*
+                    * Since we've taken L and U as a singular matrix as an input
+                    * the value for L at index i and j will be 1 when i equals j, not LU[i][j], since
+                    * the diagonal values are all 1 for L.
+                    * */
+                    if (i == j)
+                    {
+                        lij = 1;
+                    }
+                    else
+                    {
+                        lij = LU[i][j];
+                    }
+                    suml = suml + (lij * y[j]);
+                }
+                y[i] = b[pi[i]] - suml;
+            }
+            //Solve for x by using back substitution
+            for (int i = n; i >= 0; i--)
+            {
+                sumu = 0;
+                for (int j = i + 1; j <= n; j++)
+                {
+                    sumu = sumu + (LU[i][j] * x[j]);
+                }
+                x[i] = (y[i] - sumu) / LU[i][i];
+            }
+            return x;
+        }
+
+        /*
+        * Perform LUP decomposition on a matrix A.
+        * Return L and U as a single matrix(double[][]) and P as an array of ints.
+        * We implement the code to compute LU "in place" in the matrix A.
+        * In order to make some of the calculations more straight forward and to 
+        * match Cormen's et al. pseudocode the matrix A should have its first row and first columns
+        * to be all 0.
+        * */
+
+
+        /// <summary>
+        /// Perform LUP decomposition on a matrix A.
+        /// Return L and U as a single matrix(double[][]) and P as an array of ints.
+        /// We implement the code to compute LU "in place" in the matrix A.
+        /// In order to make some of the calculations more straight forward and to 
+        /// match Cormen's et al. pseudocode the matrix A should have its first row and first columns
+        /// to be all 0.
+        /// </summary>
+        /// <seealso href="http://www.rkinteractive.com/blogs/SoftwareDevelopment/post/2013/05/07/Algorithms-In-C-LUP-Decomposition.aspx"/>
+        /// <param name="A"></param>
+        /// <returns></returns>
+        private static Tuple<double[][], int[]> LUPDecomposition (double[][] A)
+        {
+            int n = A.Length - 1;
+            /*
+            * pi represents the permutation matrix.  We implement it as an array
+            * whose value indicates which column the 1 would appear.  We use it to avoid 
+            * dividing by zero or small numbers.
+            * */
+            int[] pi = new int[n + 1];
+            double p = 0;
+            int kp = 0;
+            int pik = 0;
+            int pikp = 0;
+            double aki = 0;
+            double akpi = 0;
+
+            //Initialize the permutation matrix, will be the identity matrix
+            for (int j = 0; j <= n; j++)
+            {
+                pi[j] = j;
+            }
+
+            for (int k = 0; k <= n; k++)
+            {
+                /*
+                * In finding the permutation matrix p that avoids dividing by zero
+                * we take a slightly different approach.  For numerical stability
+                * We find the element with the largest 
+                * absolute value of those in the current first column (column k).  If all elements in
+                * the current first column are zero then the matrix is singluar and throw an
+                * error.
+                * */
+                p = 0;
+                for (int i = k; i <= n; i++)
+                {
+                    if (Math.Abs (A[i][k]) > p)
+                    {
+                        p = Math.Abs (A[i][k]);
+                        kp = i;
+                    }
+                }
+                if (p == 0)
+                {
+                    throw new Exception ("singular matrix");
+                }
+                /*
+                * These lines update the pivot array (which represents the pivot matrix)
+                * by exchanging pi[k] and pi[kp].
+                * */
+                pik = pi[k];
+                pikp = pi[kp];
+                pi[k] = pikp;
+                pi[kp] = pik;
+
+                /*
+                * Exchange rows k and kpi as determined by the pivot
+                * */
+                for (int i = 0; i <= n; i++)
+                {
+                    aki = A[k][i];
+                    akpi = A[kp][i];
+                    A[k][i] = akpi;
+                    A[kp][i] = aki;
+                }
+
+                /*
+                    * Compute the Schur complement
+                    * */
+                for (int i = k + 1; i <= n; i++)
+                {
+                    A[i][k] = A[i][k] / A[k][k];
+                    for (int j = k + 1; j <= n; j++)
+                    {
+                        A[i][j] = A[i][j] - (A[i][k] * A[k][j]);
+                    }
+                }
+            }
+            return Tuple.Create (A, pi);
+        }
+
+
+        /// <summary>
+        /// Given an nXn matrix A, solve n linear equations to find the inverse of A.
+        /// </summary>
+        /// <seealso href="http://www.rkinteractive.com/blogs/SoftwareDevelopment/post/2013/05/21/Algorithms-In-C-Finding-The-Inverse-Of-A-Matrix.aspx"/>
+        /// <param name="A"></param>
+        /// <returns></returns>
+        private static double[][] InvertMatrix (double[][] A)
+        {
+            int n = A.Length;
+            //e will represent each column in the identity matrix
+            double[] e;
+            //x will hold the inverse matrix to be returned
+            double[][] x = new double[n][];
+            for (int i = 0; i < n; i++)
+            {
+                x[i] = new double[A[i].Length];
+            }
+            /*
+            * solve will contain the vector solution for the LUP decomposition as we solve
+            * for each vector of x.  We will combine the solutions into the double[][] array x.
+            * */
+            double[] solve;
+
+            //Get the LU matrix and P matrix (as an array)
+            Tuple<double[][], int[]> results = LUPDecomposition (A);
+
+            double[][] LU = results.Item1;
+            int[] P = results.Item2;
+
+            /*
+            * Solve AX = e for each column ei of the identity matrix using LUP decomposition
+            * */
+            for (int i = 0; i < n; i++)
+            {
+                e = new double[A[i].Length];
+                e[i] = 1;
+                solve = LUPSolve (LU, P, e);
+                for (int j = 0; j < solve.Length; j++)
+                {
+                    x[j][i] = solve[j];
+                }
+            }
+            return x;
+        }
+        #endregion private methods
+
+        #region public methods
+        /// <summary>
+        /// Returns the inverse of this affine transformation.
+        /// </summary>
+        /// <returns>IMathTransform that is the reverse of the current affine transformation.</returns>
+        public override IMathTransform Inverse ()
+        {
+            if (_inverse == null)
+            {
+                //if input dimension is M, and output dimension is N, then the matrix will have size [N+1][M+1].
+                double[][] srcMatrix = new double[dimTarget + 1][];
+                for (int row = 0; row <= dimTarget; row++)
+                {
+                    srcMatrix[row] = new double[dimSource + 1];
+                    for (int col = 0; col <= dimSource; col++)
+                    {
+                        srcMatrix[row][col] = transformMatrix[row, col];
+                    }
+                }
+                var invMatrix = InvertMatrix (srcMatrix);
+                //fill instance of inverted matrix for affine transform
+                double[,] matrix = new double[dimSource + 1, dimTarget + 1];
+                for (int i = 0; i <= dimSource; i++)
+                {
+                    for (int j = 0; j <= dimTarget; j++)
+                    {
+                        matrix[i, j] = invMatrix[i][j];
+                    }
+                }
+
+                _inverse = new AffineTransform (matrix);
+            }
+
+            return _inverse;
+        }
+
+        /// <summary>
+        /// Transforms a coordinate point. The passed parameter point should not be modified.
+        /// </summary>
+        /// <param name="point"></param>
+        /// <returns></returns>
+        public override double[] Transform (double[] point)
+        {
+            //check source dimensionality - alow coordinate clipping, if source dimensionality is greater then expected source dimensionality of affine transformation
+            if (point.Length >= dimSource)
+            {
+                //use transformation matrix to create output points that has dimTarget dimensionality
+                double[] transformed = new double[dimTarget];
+
+                //count each target dimension using the apropriate row
+                for (int row = 0; row < dimTarget; row++)
+                {
+                    //start with the last value which is in fact multiplied by 1
+                    double dimVal = transformMatrix[row, dimSource];
+                    for (int col = 0; col < dimSource; col++)
+                    {
+                        dimVal += transformMatrix[row, col] * point[col];
+                    }
+                    transformed[row] = dimVal;
+                }
+                return transformed;
+            }
+
+            //nepodporovane
+            throw new NotSupportedException ("Dimensionality of point is not supported!");
+        }
+
+        /// <summary>
+        /// Reverses the transformation
+        /// </summary>
+        public override void Invert ()
+        {
+            throw new NotImplementedException ("The method or operation is not implemented.");
+        }
+
+
+        /// <summary>
+        /// Returns this affine transform as an affine transform matrix.
+        /// </summary>
+        /// <returns></returns>
+        public double[,] GetMatrix ()
+        {
+            return (double[,])this.transformMatrix.Clone ();
+        }
+        #endregion public methods
+    }
+}

--- a/ProjNet/IO/CoordinateSystems/MathTransformWktReader.cs
+++ b/ProjNet/IO/CoordinateSystems/MathTransformWktReader.cs
@@ -1,0 +1,250 @@
+﻿// Copyright 2005 - 2009 - Morten Nielsen (www.sharpgis.net)
+//
+// This file is part of ProjNet.
+// ProjNet is free software; you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+// 
+// ProjNet is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public License
+// along with ProjNet; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA 
+
+// SOURCECODE IS MODIFIED FROM ANOTHER WORK AND IS ORIGINALLY BASED ON GeoTools.NET:
+/*
+ *  Copyright (C) 2002 Urban Science Applications, Inc. 
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using GeoAPI.CoordinateSystems;
+using GeoAPI.CoordinateSystems.Transformations;
+using ProjNet.CoordinateSystems;
+using ProjNet.CoordinateSystems.Transformations;
+
+namespace ProjNet.Converters.WellKnownText
+{
+    /// <summary>
+    /// Creates an math transform based on the supplied Well Known Text (WKT).
+    /// </summary>
+    public static class MathTransformWktReader
+    {
+        /// <summary>
+        /// Reads and parses a WKT-formatted projection string.
+        /// </summary>
+        /// <param name="wkt">String containing WKT.</param>
+        /// <param name="encoding">The encoding to use.</param>
+        /// <returns>Object representation of the WKT.</returns>
+        /// <exception cref="System.ArgumentException">If a token is not recognised.</exception>
+        public static IMathTransform Parse (string wkt, Encoding encoding)
+        {
+            if (String.IsNullOrEmpty (wkt))
+                throw new ArgumentNullException ("wkt");
+            if (encoding == null)
+                throw new ArgumentNullException ("encoding");
+
+            byte[] arr = encoding.GetBytes (wkt);
+            using (Stream stream = new MemoryStream (arr))
+            using (TextReader reader = new StreamReader (stream, encoding))
+            {
+                WktStreamTokenizer tokenizer = new WktStreamTokenizer (reader);
+                tokenizer.NextToken ();
+                string objectName = tokenizer.GetStringValue ();
+                switch (objectName)
+                {
+                    case "PARAM_MT":
+                        return ReadMathTransform (tokenizer);
+                    default:
+                        throw new ArgumentException (String.Format ("'{0}' is not recognized.", objectName));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Reads math transform from using current token from the specified tokenizer
+        /// </summary>
+        /// <param name="tokenizer"></param>
+        /// <returns></returns>
+        internal static IMathTransform ReadMathTransform (WktStreamTokenizer tokenizer)
+        {
+            if (tokenizer.GetStringValue () != "PARAM_MT")
+                tokenizer.ReadToken ("PARAM_MT");
+            tokenizer.ReadToken ("[");
+            string transformName = tokenizer.ReadDoubleQuotedWord ();
+            tokenizer.ReadToken (",");
+
+            switch (transformName.ToUpperInvariant ())
+            {
+                case "AFFINE":
+                    return ReadAffineTransform (tokenizer);
+                default:
+                    throw new NotSupportedException ("Transform not supported '" + transformName + "'");
+            }
+        }
+
+        private static IParameterInfo ReadParameters (WktStreamTokenizer tokenizer)
+        {
+            List<Parameter> paramList = new List<Parameter> ();
+            while (tokenizer.GetStringValue () == "PARAMETER")
+            {
+                tokenizer.ReadToken ("[");
+                string paramName = tokenizer.ReadDoubleQuotedWord ();
+                tokenizer.ReadToken (",");
+                tokenizer.NextToken ();
+                double paramValue = tokenizer.GetNumericValue ();
+                tokenizer.ReadToken ("]");
+                tokenizer.ReadToken (",");
+                paramList.Add (new Parameter (paramName, paramValue));
+                tokenizer.NextToken ();
+            }
+            IParameterInfo info = new ParameterInfo () { Parameters = paramList };
+            return info;
+        }
+
+        private static IMathTransform ReadAffineTransform (WktStreamTokenizer tokenizer)
+        {
+            /*
+                 PARAM_MT[
+                    "Affine",
+                    PARAMETER["num_row",3],
+                    PARAMETER["num_col",3],
+                    PARAMETER["elt_0_0", 0.883485346527455],
+                    PARAMETER["elt_0_1", -0.468458794848877],
+                    PARAMETER["elt_0_2", 3455869.17937689],
+                    PARAMETER["elt_1_0", 0.468458794848877],
+                    PARAMETER["elt_1_1", 0.883485346527455],
+                    PARAMETER["elt_1_2", 5478710.88035753],
+                    PARAMETER["elt_2_2", 1]
+                 ]
+            */
+            //tokenizer stands on the first PARAMETER
+            if (tokenizer.GetStringValue () != "PARAMETER")
+                tokenizer.ReadToken ("PARAMETER");
+
+            IParameterInfo paramInfo = ReadParameters (tokenizer);
+            //manage required parameters - row, col
+            Parameter rowParam = paramInfo.GetParameterByName ("num_row");
+            Parameter colParam = paramInfo.GetParameterByName ("num_col");
+
+            if (rowParam == null)
+            {
+                throw new ArgumentNullException ("Affine transform does not contain 'num_row' parameter");
+            }
+            if (colParam == null)
+            {
+                throw new ArgumentNullException ("Affine transform does not contain 'num_col' parameter");
+            }
+            int rowVal = (int)rowParam.Value;
+            int colVal = (int)colParam.Value;
+
+            if (rowVal <= 0)
+            {
+                throw new ArgumentException ("Affine transform contains invalid value of 'num_row' parameter");
+            }
+
+            if (colVal <= 0)
+            {
+                throw new ArgumentException ("Affine transform contains invalid value of 'num_col' parameter");
+            }
+
+            //creates working matrix;
+            double[,] matrix = new double[rowVal, colVal];
+
+            //simply process matrix values - no elt_ROW_COL parsing
+            foreach (Parameter param in paramInfo.Parameters)
+            {
+                if (param == null || param.Name == null)
+                {
+                    continue;
+                }
+                switch (param.Name)
+                {
+                    case "num_row":
+                    case "num_col":
+                        break;
+                    case "elt_0_0":
+                        matrix[0, 0] = param.Value;
+                        break;
+                    case "elt_0_1":
+                        matrix[0, 1] = param.Value;
+                        break;
+                    case "elt_0_2":
+                        matrix[0, 2] = param.Value;
+                        break;
+                    case "elt_0_3":
+                        matrix[0, 3] = param.Value;
+                        break;
+                    case "elt_1_0":
+                        matrix[1, 0] = param.Value;
+                        break;
+                    case "elt_1_1":
+                        matrix[1, 1] = param.Value;
+                        break;
+                    case "elt_1_2":
+                        matrix[1, 2] = param.Value;
+                        break;
+                    case "elt_1_3":
+                        matrix[1, 3] = param.Value;
+                        break;
+                    case "elt_2_0":
+                        matrix[2, 0] = param.Value;
+                        break;
+                    case "elt_2_1":
+                        matrix[2, 1] = param.Value;
+                        break;
+                    case "elt_2_2":
+                        matrix[2, 2] = param.Value;
+                        break;
+                    case "elt_2_3":
+                        matrix[2, 3] = param.Value;
+                        break;
+                    case "elt_3_0":
+                        matrix[3, 0] = param.Value;
+                        break;
+                    case "elt_3_1":
+                        matrix[3, 1] = param.Value;
+                        break;
+                    case "elt_3_2":
+                        matrix[3, 2] = param.Value;
+                        break;
+                    case "elt_3_3":
+                        matrix[3, 3] = param.Value;
+                        break;
+                    default:
+                        //unknown parameter
+                        break;
+                }
+            }
+
+            //read rest of WKT
+            if (tokenizer.GetStringValue () != "]")
+                tokenizer.ReadToken ("]");
+
+            //use "matrix" constructor to create transformation matrix
+            IMathTransform affineTransform = new AffineTransform (matrix);
+            return affineTransform;
+        }
+    }
+}

--- a/ProjNet/IO/CoordinateSystems/MathTransformWktReader.cs
+++ b/ProjNet/IO/CoordinateSystems/MathTransformWktReader.cs
@@ -106,7 +106,7 @@ namespace ProjNet.Converters.WellKnownText
 
         private static IParameterInfo ReadParameters (WktStreamTokenizer tokenizer)
         {
-            List<Parameter> paramList = new List<Parameter> ();
+            List<GeoAPI.CoordinateSystems.Parameter> paramList = new List<GeoAPI.CoordinateSystems.Parameter> ();
             while (tokenizer.GetStringValue () == "PARAMETER")
             {
                 tokenizer.ReadToken ("[");
@@ -115,9 +115,11 @@ namespace ProjNet.Converters.WellKnownText
                 tokenizer.NextToken ();
                 double paramValue = tokenizer.GetNumericValue ();
                 tokenizer.ReadToken ("]");
-                tokenizer.ReadToken (",");
-                paramList.Add (new Parameter (paramName, paramValue));
+                //test, whether next parameter is delimited by comma
                 tokenizer.NextToken ();
+                if (tokenizer.GetStringValue () != "]")
+                    tokenizer.NextToken ();
+                paramList.Add (new GeoAPI.CoordinateSystems.Parameter (paramName, paramValue));
             }
             IParameterInfo info = new ParameterInfo () { Parameters = paramList };
             return info;
@@ -145,8 +147,8 @@ namespace ProjNet.Converters.WellKnownText
 
             IParameterInfo paramInfo = ReadParameters (tokenizer);
             //manage required parameters - row, col
-            Parameter rowParam = paramInfo.GetParameterByName ("num_row");
-            Parameter colParam = paramInfo.GetParameterByName ("num_col");
+            var rowParam = paramInfo.GetParameterByName ("num_row");
+            var colParam = paramInfo.GetParameterByName ("num_col");
 
             if (rowParam == null)
             {
@@ -173,7 +175,7 @@ namespace ProjNet.Converters.WellKnownText
             double[,] matrix = new double[rowVal, colVal];
 
             //simply process matrix values - no elt_ROW_COL parsing
-            foreach (Parameter param in paramInfo.Parameters)
+            foreach (var param in paramInfo.Parameters)
             {
                 if (param == null || param.Name == null)
                 {

--- a/ProjNet/ProjNET.csproj
+++ b/ProjNet/ProjNET.csproj
@@ -64,6 +64,7 @@
     <Compile Include="CoordinateSystems\GeographicTransform.cs" />
     <Compile Include="CoordinateSystems\HorizontalCoordinateSystem.cs" />
     <Compile Include="CoordinateSystems\HorizontalDatum.cs" />
+    <Compile Include="CoordinateSystems\ParameterInfo.cs" />
     <Compile Include="CoordinateSystems\Projections\CassiniSoldnerProjection.cs" />
     <Compile Include="CoordinateSystems\Projections\HotineObliqueMercatorProjection.cs" />
     <Compile Include="CoordinateSystems\Projections\PolyconicProjection.cs" />
@@ -79,6 +80,7 @@
     <Compile Include="CoordinateSystems\Projections\Mercator.cs" />
     <Compile Include="CoordinateSystems\Projections\ProjectionParameterSet.cs" />
     <Compile Include="CoordinateSystems\Projections\TransverseMercator.cs" />
+    <Compile Include="CoordinateSystems\Transformations\AffineTransform.cs" />
     <Compile Include="CoordinateSystems\Transformations\ConcatenatedTransform.cs" />
     <Compile Include="CoordinateSystems\Transformations\CoordinateTransformation.cs" />
     <Compile Include="CoordinateSystems\Transformations\CoordinateTransformationFactory.cs" />
@@ -89,6 +91,7 @@
     <Compile Include="CoordinateSystems\Projections\ProjectionsRegistry.cs" />
     <Compile Include="CoordinateSystems\Unit.cs" />
     <Compile Include="IO\CoordinateSystems\CoordinateSystemWktReader.cs" />
+    <Compile Include="IO\CoordinateSystems\MathTransformWktReader.cs" />
     <Compile Include="IO\CoordinateSystems\StreamTokenizer.cs" />
     <Compile Include="IO\CoordinateSystems\TokenType.cs" />
     <Compile Include="IO\CoordinateSystems\WKTStreamTokenizer.cs" />
@@ -104,6 +107,7 @@
     <Reference Include="GeoAPI">
       <HintPath>..\packages\GeoAPI.$(GeoAPIPackageVersion)\lib\$(fwVersion)\GeoAPI.dll</HintPath>
     </Reference>
+    <Reference Include="System" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)GeoAPI.props" />


### PR DESCRIPTION
Base implementation of affine math transform that may be used in some fitted coordinate system (including WKT parsing).
Following unit test were added:
- AffineTransformationTest
- InverseAffineTransformationTest
- ParseAffineTransformWkt
- ParseFittedCoordinateSystemWkt
- TestTransformOnFittedCoordinateSystem

Example of fitted coordinate system:
           Local coordinate system MNAU (Kraftwerk Mäuserich) (based on Gauß-Krüger using affine transformation)
            Affine transform
             1) Offset: X=-3454886,640m Y=-5479481,278m;
             2) Rotation: 332,0657, Rotation point  X=3456926,640m Y=5481071,278m;
             3) Scale: 1.0