### PR TITLE
Added unit test that covers WKT parsing of numeric values with exponent notation

### DIFF
--- a/ProjNET.Pcl/ProjNET.Pcl.csproj
+++ b/ProjNET.Pcl/ProjNET.Pcl.csproj
@@ -134,6 +134,9 @@
     <Compile Include="..\ProjNet\CoordinateSystems\Transformations\AffineTransform.cs">
       <Link>CoordinateSystems\Transformations\AffineTransform.cs</Link>
     </Compile>
+    <Compile Include="..\ProjNet\CoordinateSystems\Transformations\PrimeMeridianTransform.cs">
+      <Link>CoordinateSystems\Transformations\PrimeMeridianTransform.cs</Link>
+    </Compile>
     <Compile Include="..\ProjNet\CoordinateSystems\Transformations\ConcatenatedTransform.cs">
       <Link>CoordinateSystems\Transformations\ConcatenatedTransform.cs</Link>
     </Compile>

--- a/ProjNet.Tests/CoordinateTransformTests.cs
+++ b/ProjNet.Tests/CoordinateTransformTests.cs
@@ -410,17 +410,30 @@ namespace ProjNet.UnitTests
 			//Point3D pGeoCenWGS84 = wgs72.Wgs84Parameters.Apply(pGeoCenWGS72);
 		    double[] pExpected = new[] {3657660.78, 255778.43, 5201387.75};
             Assert.IsTrue(ToleranceLessThan(pExpected, pGeoCenWGS84, 0.01), TransformationError("Datum WGS72->WGS84", pExpected, pGeoCenWGS84));
+            //and inverse
+            double[] pGeoCenWGS72calc = geocen_ed50_2_Wgs84.MathTransform.Inverse().Transform(pGeoCenWGS84);
+            Assert.IsTrue(ToleranceLessThan(pGeoCenWGS72, pGeoCenWGS72calc, 0.001), TransformationError("Datum WGS84->WGS72", pGeoCenWGS72, pGeoCenWGS72calc));
 
 			ICoordinateTransformation utm_ed50_2_Wgs84 = CoordinateTransformationFactory.CreateFromCoordinateSystems(utmED50, utmWGS84);
 			double[] pUTMED50 = new double[] {600000, 6100000};
 			double[] pUTMWGS84 = utm_ed50_2_Wgs84.MathTransform.Transform(pUTMED50);
             pExpected = new[] { 599928.6, 6099790.2};
             Assert.IsTrue(ToleranceLessThan(pExpected, pUTMWGS84, 0.1), TransformationError("Datum ED50->WGS84", pExpected, pUTMWGS84));
+            //and inverse
+            double[] pUTMED50calc = utm_ed50_2_Wgs84.MathTransform.Inverse().Transform(pUTMWGS84);
+            Assert.IsTrue(ToleranceLessThan(pUTMED50, pUTMED50calc, 0.01), TransformationError("Datum WGS84->ED50", pUTMED50, pUTMED50calc));
+
+
 			//Perform reverse
 			ICoordinateTransformation utm_Wgs84_2_Ed50 = CoordinateTransformationFactory.CreateFromCoordinateSystems(utmWGS84, utmED50);
 			pUTMED50 = utm_Wgs84_2_Ed50.MathTransform.Transform(pUTMWGS84);
 		    pExpected = new double[] {600000, 6100000};
             Assert.IsTrue(ToleranceLessThan(pExpected, pUTMED50, 0.1), TransformationError("Datum", pExpected, pUTMED50));
+            //and inverse
+            double[] pUTMWGS84calc = utm_Wgs84_2_Ed50.MathTransform.Inverse().Transform(pUTMED50);
+            Assert.IsTrue(ToleranceLessThan(pUTMWGS84, pUTMWGS84calc, 0.1), TransformationError("Datum", pUTMWGS84, pUTMWGS84calc));
+
+
 			//Assert.IsTrue(Math.Abs((pUTMWGS84 as Point3D).Z - 36.35) < 0.5);
 			//Point pExpected = Point.FromDMS(2, 7, 46.38, 53, 48, 33.82);
 			//ED50_to_WGS84_Denmark: datum.Wgs84Parameters = new Wgs84ConversionInfo(-89.5, -93.8, 127.6, 0, 0, 4.5, 1.2);

--- a/ProjNet.Tests/CoordinateTransformTests.cs
+++ b/ProjNet.Tests/CoordinateTransformTests.cs
@@ -738,6 +738,13 @@ namespace ProjNet.UnitTests
             // Start point (MNAU) X=2040,000m Y=1590,000m]
             // Target point (GK): X=3456926,640m Y=5481071,278m;
 
+            //check source transform
+            double[] outPt = mt.Transform (new double[] { 2040.0, 1590.0 });
+
+            Assert.AreEqual (2, outPt.Length);
+            Assert.AreEqual (3456926.640, outPt[0], 0.00000001);
+            Assert.AreEqual (5481071.278, outPt[1], 0.00000001);
+
             IMathTransform invMt = mt.Inverse ();
 
             double[] inPt = invMt.Transform (new double[] { 3456926.640, 5481071.278 });
@@ -745,6 +752,13 @@ namespace ProjNet.UnitTests
             Assert.AreEqual (2, inPt.Length);
             Assert.AreEqual (2040.0, inPt[0], 0.00000001);
             Assert.AreEqual (1590.0, inPt[1], 0.00000001);
+
+            //check source transform - once more
+            double[] outPt2 = mt.Transform (new double[] { 2040.0, 1590.0 });
+
+            Assert.AreEqual (2, outPt2.Length);
+            Assert.AreEqual (3456926.640, outPt2[0], 0.00000001);
+            Assert.AreEqual (5481071.278, outPt2[1], 0.00000001);
         }
 
         /// <summary>

--- a/ProjNet.Tests/CoordinateTransformTests.cs
+++ b/ProjNet.Tests/CoordinateTransformTests.cs
@@ -721,5 +721,39 @@ namespace ProjNet.UnitTests
             Assert.AreEqual (3456926.640, transformedCoords[0][0], 0.00000001);
             Assert.AreEqual (5481071.278, transformedCoords[0][1], 0.00000001);
         }
+
+        /// <summary>
+        /// test for epsg 21780 projection (different prime meridian)
+        /// </summary>
+        [Test]
+        public void Test_EPSG_21780_PrimeMeredianTransformation()
+        {
+            string wkt4326 = "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]";
+            string wkt21780 = "PROJCS[\"Bern 1898 (Bern) / LV03C\",GEOGCS[\"Bern 1898 (Bern)\",DATUM[\"CH1903_Bern\",SPHEROID[\"Bessel 1841\",6377397.155,299.1528128,AUTHORITY[\"EPSG\",\"7004\"]],AUTHORITY[\"EPSG\",\"6801\"]],PRIMEM[\"Bern\",7.439583333333333,AUTHORITY[\"EPSG\",\"8907\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4801\"]],PROJECTION[\"Hotine_Oblique_Mercator\"],PARAMETER[\"latitude_of_center\",46.95240555555556],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"azimuth\",90],PARAMETER[\"rectified_grid_angle\",90],PARAMETER[\"scale_factor\",1],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AUTHORITY[\"EPSG\",\"21780\"]]";
+
+            //test data from http://spatialreference.org/ref/epsg/21780/
+            double[] sourceCoord = new double[] { 160443.329034, 23582.55586 };
+            double[] expectedTargetCoord = new double[] { 9.5553588867188, 47.145080566406 };
+
+            ICoordinateSystem cs1 = ProjNet.Converters.WellKnownText.CoordinateSystemWktReader.Parse(wkt21780, System.Text.Encoding.Default) as ICoordinateSystem;
+            ICoordinateSystem cs2 = ProjNet.Converters.WellKnownText.CoordinateSystemWktReader.Parse(wkt4326, System.Text.Encoding.Default) as ICoordinateSystem;
+            CoordinateTransformationFactory ctf = new CoordinateTransformationFactory();
+            var ict = ctf.CreateFromCoordinateSystems(cs1, cs2);
+
+            double[] transformedCoord = ict.MathTransform.Transform(sourceCoord);
+
+            Assert.IsTrue(transformedCoord.Length >= 2);
+            Assert.AreEqual(expectedTargetCoord[0], transformedCoord[0], 0.001);
+            Assert.AreEqual(expectedTargetCoord[1], transformedCoord[1], 0.001);
+
+            //and back
+            var ictb = ctf.CreateFromCoordinateSystems(cs2, cs1);
+            transformedCoord = ictb.MathTransform.Transform(transformedCoord);
+
+            Assert.IsTrue(transformedCoord.Length >= 2);
+            Assert.AreEqual(sourceCoord[0], transformedCoord[0], 0.1);
+            Assert.AreEqual(sourceCoord[1], transformedCoord[1], 0.1);
+
+        }
     }
 }

--- a/ProjNet.Tests/WKT/WKTMathTransformParserTests.cs
+++ b/ProjNet.Tests/WKT/WKTMathTransformParserTests.cs
@@ -54,5 +54,32 @@ namespace ProjNet.UnitTests.Converters.WKT
             Assert.AreEqual (3455869.17937689, outPt[0], 0.00000001);
             Assert.AreEqual (5478710.88035753, outPt[1], 0.00000001);
         }
+
+        /// <summary>
+        /// MathTransformWktReader parses real number with exponent incorrectly
+        /// </summary>
+        [Test]
+        public void TestMathTransformWktReaderExponencialNumberParsingIssue ()
+        {
+            string wkt = "PARAM_MT[\"Affine\",PARAMETER[\"num_row\", 3],PARAMETER[\"num_col\", 3],PARAMETER[\"elt_0_0\", 6.12303176911189E-17]]";
+            IMathTransform mt = null;
+
+            try
+            {
+                //TODO replace with MathTransformFactory implementation
+                mt = MathTransformWktReader.Parse (wkt, System.Text.Encoding.Unicode);
+            }
+            catch (ArgumentException ex)
+            {
+                Assert.Fail ("Failed to parse WKT of affine math transformation from:\r\n" + wkt + "\r\n" + ex.Message);
+            }
+            catch (Exception e)
+            {
+                Assert.Fail ("Could not create affine math transformation from:\r\n" + wkt + "\r\n" + e.Message);
+            }
+
+            Assert.IsNotNull (mt);
+            Assert.IsNotNull (mt as AffineTransform);
+        }
     }
 }

--- a/ProjNet/CoordinateSystems/PrimeMeridian.cs
+++ b/ProjNet/CoordinateSystems/PrimeMeridian.cs
@@ -113,7 +113,7 @@ namespace ProjNet.CoordinateSystems
 		/// </summary>
 		public static PrimeMeridian Ferro
 		{
-			get { return new PrimeMeridian(-17.4, CoordinateSystems.AngularUnit.Degrees, "Ferro", "EPSG", 8909, String.Empty, String.Empty, "Used in Austria and former Czechoslovakia."); }
+            get { return new PrimeMeridian(-17.66666666666667, CoordinateSystems.AngularUnit.Degrees, "Ferro", "EPSG", 8909, String.Empty, String.Empty, "Used in Austria and former Czechoslovakia."); }
 		}
 		/// <summary>
 		/// Brussels prime meridian

--- a/ProjNet/CoordinateSystems/Projections/KrovakProjection.cs
+++ b/ProjNet/CoordinateSystems/Projections/KrovakProjection.cs
@@ -157,8 +157,6 @@ namespace ProjNet.CoordinateSystems.Projections
 			//Check for missing parameters
             _azimuth = Degrees2Radians(_Parameters.GetParameterValue("azimuth"));
 			_pseudoStandardParallel = Degrees2Radians(_Parameters.GetParameterValue("pseudo_standard_parallel_1"));
-
-            central_meridian = Degrees2Radians(24 + (50.0 / 60));// par_longitude_of_center.Value);
             
             // Calculates useful constants.
 			_sinAzim = Math.Sin(_azimuth);

--- a/ProjNet/CoordinateSystems/Transformations/AffineTransform.cs
+++ b/ProjNet/CoordinateSystems/Transformations/AffineTransform.cs
@@ -395,9 +395,9 @@ namespace ProjNet.CoordinateSystems.Transformations
         {
             if (_inverse == null)
             {
-                //find the inverse transformation matrix
+                //find the inverse transformation matrix - use cloned matrix array
                 //remarks about dimensionality: if input dimension is M, and output dimension is N, then the matrix will have size [N+1][M+1].
-                var invMatrix = InvertMatrix (transformMatrix);
+                var invMatrix = InvertMatrix ((double[,])transformMatrix.Clone ());
                 _inverse = new AffineTransform (invMatrix);
             }
 

--- a/ProjNet/CoordinateSystems/Transformations/CoordinateTransformationFactory.cs
+++ b/ProjNet/CoordinateSystems/Transformations/CoordinateTransformationFactory.cs
@@ -95,17 +95,37 @@ namespace ProjNet.CoordinateSystems.Transformations
 
 		#region Methods for converting between specific systems
 
-		private static ICoordinateTransformation Geog2Geoc(IGeographicCoordinateSystem source, IGeocentricCoordinateSystem target)
-		{
-			IMathTransform geocMathTransform = CreateCoordinateOperation(target);
-			return new CoordinateTransformation(source, target, TransformType.Conversion, geocMathTransform, String.Empty, String.Empty, -1, String.Empty, String.Empty);
-		}
+        private static ICoordinateTransformation Geog2Geoc(IGeographicCoordinateSystem source, IGeocentricCoordinateSystem target)
+        {
+            IMathTransform geocMathTransform = CreateCoordinateOperation(target);
+            if (source.PrimeMeridian.EqualParams(target.PrimeMeridian))
+            {
+                return new CoordinateTransformation(source, target, TransformType.Conversion, geocMathTransform, String.Empty, String.Empty, -1, String.Empty, String.Empty);
+            }
+            else
+            {
+                var ct = new ConcatenatedTransform();
+                ct.CoordinateTransformationList.Add(new CoordinateTransformation(source, target, TransformType.Transformation, new PrimeMeridianTransform(source.PrimeMeridian, target.PrimeMeridian), String.Empty, String.Empty, -1, String.Empty, String.Empty));
+                ct.CoordinateTransformationList.Add(new CoordinateTransformation(source, target, TransformType.Conversion, geocMathTransform, String.Empty, String.Empty, -1, String.Empty, String.Empty));
+                return new CoordinateTransformation(source, target, TransformType.Conversion, ct, String.Empty, String.Empty, -1, String.Empty, String.Empty);
+            }
+        }
 
-		private static ICoordinateTransformation Geoc2Geog(IGeocentricCoordinateSystem source, IGeographicCoordinateSystem target)
-		{
-			IMathTransform geocMathTransform = CreateCoordinateOperation(source).Inverse();
-			return new CoordinateTransformation(source, target, TransformType.Conversion, geocMathTransform, String.Empty, String.Empty, -1, String.Empty, String.Empty);
-		}
+        private static ICoordinateTransformation Geoc2Geog(IGeocentricCoordinateSystem source, IGeographicCoordinateSystem target)
+        {
+            IMathTransform geocMathTransform = CreateCoordinateOperation(source).Inverse();
+            if (source.PrimeMeridian.EqualParams(target.PrimeMeridian))
+            {
+                return new CoordinateTransformation(source, target, TransformType.Conversion, geocMathTransform, String.Empty, String.Empty, -1, String.Empty, String.Empty);
+            }
+            else
+            {
+                var ct = new ConcatenatedTransform();
+                ct.CoordinateTransformationList.Add(new CoordinateTransformation(source, target, TransformType.Conversion, geocMathTransform, String.Empty, String.Empty, -1, String.Empty, String.Empty));
+                ct.CoordinateTransformationList.Add(new CoordinateTransformation(source, target, TransformType.Transformation, new PrimeMeridianTransform(source.PrimeMeridian, target.PrimeMeridian), String.Empty, String.Empty, -1, String.Empty, String.Empty));
+                return new CoordinateTransformation(source, target, TransformType.Conversion, ct, String.Empty, String.Empty, -1, String.Empty, String.Empty);
+            }
+        }
 		
 		private static ICoordinateTransformation Proj2Proj(IProjectedCoordinateSystem source, IProjectedCoordinateSystem target)
 		{

--- a/ProjNet/CoordinateSystems/Transformations/DatumTransform.cs
+++ b/ProjNet/CoordinateSystems/Transformations/DatumTransform.cs
@@ -91,21 +91,34 @@ namespace ProjNet.CoordinateSystems.Transformations
 			return _inverse;
 		}
 
+        /// <summary>
+        /// Transforms a coordinate point.
+        /// </summary>
+        /// <param name="p"></param>
+        /// <returns></returns>
+        /// <seealso href="http://en.wikipedia.org/wiki/Helmert_transformation"/>
         private double[] Apply(double[] p)
-		{
+        {
             return new double[] {
-				v[0] * p[0] - v[3] * p[1] + v[2] * p[2] + v[4],
-				v[3] * p[0] + v[0] * p[1] - v[1] * p[2] + v[5],
-			   -v[2] * p[0] + v[1] * p[1] + v[0] * p[2] + v[6], };			
-		}
+				v[0] * (p[0] - v[3] * p[1] + v[2] * p[2]) + v[4],
+				v[0] * (v[3] * p[0] + p[1] - v[1] * p[2]) + v[5],
+			    v[0] * (-v[2] * p[0] + v[1] * p[1] + p[2]) + v[6], };
+        }
 
+        /// <summary>
+        /// For the reverse transformation, each element is multiplied by -1.
+        /// </summary>
+        /// <param name="p"></param>
+        /// <returns></returns>
+        /// <seealso href="http://en.wikipedia.org/wiki/Helmert_transformation"/>
         private double[] ApplyInverted(double[] p)
-		{
+        {
+
             return new double[] {
-				v[0] * p[0] + v[3] * p[1] - v[2] * p[2] - v[4],
-			   -v[3] * p[0] + v[0] * p[1] + v[1] * p[2] - v[5],
-			    v[2] * p[0] - v[1] * p[1] + v[0] * p[2] - v[6], };
-		}
+				(1-(v[0]-1)) * (p[0] + v[3] * p[1] - v[2] * p[2]) - v[4],
+			    (1-(v[0]-1)) * (-v[3] * p[0] + p[1] + v[1] * p[2]) - v[5],
+			    (1-(v[0]-1)) * ( v[2] * p[0] - v[1] * p[1] + p[2]) - v[6], };
+        }
 
         /// <summary>
         /// Transforms a coordinate point. The passed parameter point should not be modified.

--- a/ProjNet/CoordinateSystems/Transformations/PrimeMeridianTransform.cs
+++ b/ProjNet/CoordinateSystems/Transformations/PrimeMeridianTransform.cs
@@ -1,0 +1,126 @@
+﻿// Copyright 2005 - 2009 - Morten Nielsen (www.sharpgis.net)
+//
+// This file is part of ProjNet.
+// ProjNet is free software; you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+// 
+// ProjNet is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public License
+// along with ProjNet; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA 
+
+using GeoAPI.CoordinateSystems;
+using GeoAPI.CoordinateSystems.Transformations;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace ProjNet.CoordinateSystems.Transformations
+{
+
+    /// <summary>
+    /// Adjusts target Prime Meridian
+    /// </summary>
+#if !PCL
+    [Serializable]
+#endif
+    internal class PrimeMeridianTransform : MathTransform
+    {
+        #region class variables
+        private IPrimeMeridian _source;
+        private IPrimeMeridian _target;
+        #endregion class variables
+
+        #region constructors & finalizers
+        /// <summary>
+        /// Creates instance prime meridian transform
+        /// </summary>
+        /// <param name="source"></param>
+        /// <param name="target"></param>
+        public PrimeMeridianTransform(IPrimeMeridian source, IPrimeMeridian target)
+            : base()
+        {
+            if (!source.AngularUnit.EqualParams(target.AngularUnit))
+            {
+                throw new NotImplementedException("The method or operation is not implemented.");  
+            }
+            _source = source;
+            _target = target;            
+        }
+
+
+        #endregion constructors & finalizers
+
+        #region public properties
+        /// <summary>
+        /// Gets a Well-Known text representation of this affine math transformation.
+        /// </summary>
+        /// <value></value>
+        public override string WKT
+        {
+            get { throw new NotImplementedException("The method or operation is not implemented."); }
+        }
+        /// <summary>
+        /// Gets an XML representation of this affine transformation.
+        /// </summary>
+        /// <value></value>
+        public override string XML
+        {
+            get { throw new NotImplementedException("The method or operation is not implemented."); }
+        }
+
+        /// <summary>
+        /// Gets the dimension of input points.
+        /// </summary>
+        public override int DimSource { get { return 3; } }
+
+        /// <summary>
+        /// Gets the dimension of output points.
+        /// </summary>
+        public override int DimTarget { get { return 3; } }
+        #endregion public properties
+
+        #region public methods
+        /// <summary>
+        /// Returns the inverse of this affine transformation.
+        /// </summary>
+        /// <returns>IMathTransform that is the reverse of the current affine transformation.</returns>
+        public override IMathTransform Inverse()
+        {
+            return new PrimeMeridianTransform(_target, _source);
+        }
+
+        /// <summary>
+        /// Transforms a coordinate point. The passed parameter point should not be modified.
+        /// </summary>
+        /// <param name="point"></param>
+        /// <returns></returns>
+        public override double[] Transform(double[] point)
+        {
+            double[] transformed = new double[point.Length];
+
+            transformed[0] = point[0] + _source.Longitude - _target.Longitude;
+            transformed[1] = point[1];
+            if (point.Length > 2)
+                transformed[2] = point[2];
+            return transformed;
+        }
+
+        /// <summary>
+        /// Reverses the transformation
+        /// </summary>
+        public override void Invert()
+        {
+            throw new NotImplementedException("The method or operation is not implemented.");
+        }
+
+        #endregion public methods
+    }
+}

--- a/ProjNet/CoordinateSystems/Transformations/PrimeMeridianTransform.cs
+++ b/ProjNet/CoordinateSystems/Transformations/PrimeMeridianTransform.cs
@@ -34,6 +34,7 @@ namespace ProjNet.CoordinateSystems.Transformations
     internal class PrimeMeridianTransform : MathTransform
     {
         #region class variables
+        private bool _isInverted = false;
         private IPrimeMeridian _source;
         private IPrimeMeridian _target;
         #endregion class variables
@@ -105,8 +106,11 @@ namespace ProjNet.CoordinateSystems.Transformations
         public override double[] Transform(double[] point)
         {
             double[] transformed = new double[point.Length];
-
-            transformed[0] = point[0] + _source.Longitude - _target.Longitude;
+            
+            if (!_isInverted)
+                transformed[0] = point[0] + _source.Longitude - _target.Longitude;
+            else
+                transformed[0] = point[0] + _target.Longitude - _source.Longitude;
             transformed[1] = point[1];
             if (point.Length > 2)
                 transformed[2] = point[2];
@@ -118,7 +122,7 @@ namespace ProjNet.CoordinateSystems.Transformations
         /// </summary>
         public override void Invert()
         {
-            throw new NotImplementedException("The method or operation is not implemented.");
+            this._isInverted = !this._isInverted;
         }
 
         #endregion public methods

--- a/ProjNet/ProjNET.csproj
+++ b/ProjNet/ProjNET.csproj
@@ -89,6 +89,7 @@
     <Compile Include="CoordinateSystems\Transformations\GeographicTransform.cs" />
     <Compile Include="CoordinateSystems\Transformations\MathTransform.cs" />
     <Compile Include="CoordinateSystems\Projections\ProjectionsRegistry.cs" />
+    <Compile Include="CoordinateSystems\Transformations\PrimeMeridianTransform.cs" />
     <Compile Include="CoordinateSystems\Unit.cs" />
     <Compile Include="IO\CoordinateSystems\CoordinateSystemWktReader.cs" />
     <Compile Include="IO\CoordinateSystems\MathTransformWktReader.cs" />


### PR DESCRIPTION
This unit test shows that StreamTokenizer class does not support parsing of numeric values that contains exponent notation (e.g. 1.045789E-9).