### PR TITLE
Tweak how we use spans

### DIFF
--- a/ProjNet.Tests/CoordinateTransformTests.cs
+++ b/ProjNet.Tests/CoordinateTransformTests.cs
@@ -101,7 +101,7 @@ namespace ProjNet.UnitTests
                     new Coordinate(290596.615, 6713943.567), new Coordinate(290596.701, 6713939.485)
                 };
             var seq = CoordinateSystemServices.CoordinateSequenceFactory.Create(points);
-            ICoordinateSequence tpoints = ((MathTransform)trans1.MathTransform).Transform(seq, false);
+            ICoordinateSequence tpoints = ((MathTransform)trans1.MathTransform).TransformCopy(seq);
             for (int i = 0; i < seq.Count; i++)
                 Assert.AreEqual(trans1.MathTransform.Transform(seq.GetCoordinate(i)), tpoints.GetCoordinate(i));
         }

--- a/ProjNet/CoordinateSystems/Projections/KrovakProjection.cs
+++ b/ProjNet/CoordinateSystems/Projections/KrovakProjection.cs
@@ -83,6 +83,8 @@ namespace ProjNet.CoordinateSystems.Projections
 		 */
 		private readonly double _sinAzim, _cosAzim, _n, _tanS2, _alfa, _hae, _k1, _ka, _ro0, _rop;
 
+        private readonly double _reciprocSemiMajor;
+
 		/**
 		 * Useful constant - 45° in radians.
 		 */
@@ -178,7 +180,9 @@ namespace ProjNet.CoordinateSystems.Projections
 
 			_ro0 = scale_factor * radius / Math.Tan(_pseudoStandardParallel);
 			_rop = _ro0 * Math.Pow(_tanS2, _n);
-		}
+
+            _reciprocSemiMajor = 1 / _semiMajor;
+        }
         #endregion
 
         ///// <summary>
@@ -212,122 +216,114 @@ namespace ProjNet.CoordinateSystems.Projections
         /// </summary>
         /// <param name="lonlat">The point in decimal degrees.</param>
         /// <returns>Point in projected meters</returns>
-        protected override void RadiansToMeters(ref Span<double> lonlat, ref Span<double> altitude)
+        protected override (double x, double y, double z) RadiansToMeters(double lon, double lat, double z)
 		{
-            int size = lonlat.Length / 2;
-            for (int i = 0, j = 0; i < size; i++, j += 2)
-            {
-                int k = j + 1;
-                double lambda = lonlat[j] - central_meridian;
-                double phi = lonlat[k];
+            double lambda = lon - central_meridian;
+            double phi = lat;
 
-                double esp = _e * Math.Sin(phi);
-                double gfi = Math.Pow(((1.0 - esp) / (1.0 + esp)), _hae);
-                double u = 2 * (Math.Atan(Math.Pow(Math.Tan(phi / 2 + S45), _alfa) / _k1 * gfi) - S45);
-                double deltav = -lambda * _alfa;
-                double cosU = Math.Cos(u);
-                double s = Math.Asin((_cosAzim * Math.Sin(u)) + (_sinAzim * cosU * Math.Cos(deltav)));
-                double d = Math.Asin(cosU * Math.Sin(deltav) / Math.Cos(s));
-                double eps = _n * d;
-                double ro = _rop / Math.Pow(Math.Tan(s / 2 + S45), _n);
+            double esp = _e * Math.Sin(phi);
+            double gfi = Math.Pow(((1.0 - esp) / (1.0 + esp)), _hae);
+            double u = 2 * (Math.Atan(Math.Pow(Math.Tan(phi / 2 + S45), _alfa) / _k1 * gfi) - S45);
+            double deltav = -lambda * _alfa;
+            double cosU = Math.Cos(u);
+            double s = Math.Asin((_cosAzim * Math.Sin(u)) + (_sinAzim * cosU * Math.Cos(deltav)));
+            double d = Math.Asin(cosU * Math.Sin(deltav) / Math.Cos(s));
+            double eps = _n * d;
+            double ro = _rop / Math.Pow(Math.Tan(s / 2 + S45), _n);
 
-                /* x and y are reverted  */
-                lonlat[k] = -(ro * Math.Cos(eps)) * _semiMajor;
-                lonlat[j] = -(ro * Math.Sin(eps)) * _semiMajor;
-            }
+            /* x and y are reverted  */
+            double y = -(ro * Math.Cos(eps)) * _semiMajor;
+            double x = -(ro * Math.Sin(eps)) * _semiMajor;
+            return (x, y, z);
 		}
 
-		///// <summary>
-		///// Converts coordinates in projected meters to decimal degrees.
-		///// </summary>
-		///// <param name="p">Point in meters</param>
-		///// <returns>Transformed point in decimal degrees</returns>
-  //      protected override double[] MetersToRadians(double[] p)
-		//{
-  //          var x = p[0] / _semiMajor;
-  //          var y = p[1] / _semiMajor;
+        ///// <summary>
+        ///// Converts coordinates in projected meters to decimal degrees.
+        ///// </summary>
+        ///// <param name="p">Point in meters</param>
+        ///// <returns>Transformed point in decimal degrees</returns>
+        //      protected override double[] MetersToRadians(double[] p)
+        //{
+        //          var x = p[0] / _semiMajor;
+        //          var y = p[1] / _semiMajor;
 
-		//	// x -> southing, y -> westing
-		//	var ro = Math.Sqrt(x * x + y * y);
-		//	var eps = Math.Atan2(-x, -y);
-		//	var d   = eps / _n;
-		//	var s   = 2 * (Math.Atan(Math.Pow(_ro0/ro, 1/_n) * _tanS2) - S45);
-		//	var cs  = Math.Cos(s);
-		//	var u   = Math.Asin((_cosAzim * Math.Sin(s)) - (_sinAzim * cs * Math.Cos(d)));
-		//	var kau = _ka * Math.Pow(Math.Tan((u / 2.0) + S45), 1 / _alfa);
-		//	var deltav = Math.Asin((cs * Math.Sin(d)) / Math.Cos(u));
-		//	var lambda = -deltav / _alfa;
-		//	var phi = 0d;
+        //	// x -> southing, y -> westing
+        //	var ro = Math.Sqrt(x * x + y * y);
+        //	var eps = Math.Atan2(-x, -y);
+        //	var d   = eps / _n;
+        //	var s   = 2 * (Math.Atan(Math.Pow(_ro0/ro, 1/_n) * _tanS2) - S45);
+        //	var cs  = Math.Cos(s);
+        //	var u   = Math.Asin((_cosAzim * Math.Sin(s)) - (_sinAzim * cs * Math.Cos(d)));
+        //	var kau = _ka * Math.Pow(Math.Tan((u / 2.0) + S45), 1 / _alfa);
+        //	var deltav = Math.Asin((cs * Math.Sin(d)) / Math.Cos(u));
+        //	var lambda = -deltav / _alfa;
+        //	var phi = 0d;
 
-		//	// iteration calculation
-		//	for (var i=MaximumIterations;;) 
-		//	{
-		//		var fi1 = phi;
-		//		var esf = _e * Math.Sin(fi1);
-		//		phi = 2.0 * (Math.Atan(kau * Math.Pow((1.0 + esf) / (1.0 - esf), _e /2.0)) - S45);
-		//		if (Math.Abs(fi1 - phi) <= IterationTolerance) 
-		//		{
-		//			break;
-		//		}
+        //	// iteration calculation
+        //	for (var i=MaximumIterations;;) 
+        //	{
+        //		var fi1 = phi;
+        //		var esf = _e * Math.Sin(fi1);
+        //		phi = 2.0 * (Math.Atan(kau * Math.Pow((1.0 + esf) / (1.0 - esf), _e /2.0)) - S45);
+        //		if (Math.Abs(fi1 - phi) <= IterationTolerance) 
+        //		{
+        //			break;
+        //		}
 
-		//		if (--i < 0) 
-		//		{
-  //                  break;
-		//			//throw new ProjectionException(Errors.format(ErrorKeys.NO_CONVERGENCE));
-		//		}
-		//	}
+        //		if (--i < 0) 
+        //		{
+        //                  break;
+        //			//throw new ProjectionException(Errors.format(ErrorKeys.NO_CONVERGENCE));
+        //		}
+        //	}
 
-		//	return new[] { lambda + central_meridian, phi };
-		//}
+        //	return new[] { lambda + central_meridian, phi };
+        //}
 
         /// <summary>
         /// Converts coordinates in projected meters to decimal degrees.
         /// </summary>
         /// <param name="p">Point in meters</param>
         /// <returns>Transformed point in decimal degrees</returns>
-        protected override void MetersToRadians(ref Span<double> p, ref Span<double> altitudes)
+        protected override (double lon, double lat, double z) MetersToRadians(double x, double y, double z)
         {
-            int size = p.Length / 2;
-            for (int i = 0, j = 0; i < size; i++, j += 2)
+            x *= _reciprocSemiMajor;
+            y *= _reciprocSemiMajor;
+
+            // x -> southing, y -> westing
+            double ro = Math.Sqrt(x * x + y * y);
+            double eps = Math.Atan2(-x, -y);
+            double d = eps / _n;
+            double s = 2 * (Math.Atan(Math.Pow(_ro0 / ro, 1 / _n) * _tanS2) - S45);
+            double cs = Math.Cos(s);
+            double u = Math.Asin((_cosAzim * Math.Sin(s)) - (_sinAzim * cs * Math.Cos(d)));
+            double kau = _ka * Math.Pow(Math.Tan((u / 2.0) + S45), 1 / _alfa);
+            double deltav = Math.Asin((cs * Math.Sin(d)) / Math.Cos(u));
+            double lambda = -deltav / _alfa;
+            double phi = 0d;
+
+            // iteration calculation
+            for (int iter = MaximumIterations;;)
             {
-                int k = j + 1;
-                double x = p[j] / _semiMajor;
-                double y = p[k] / _semiMajor;
-
-                // x -> southing, y -> westing
-                double ro = Math.Sqrt(x * x + y * y);
-                double eps = Math.Atan2(-x, -y);
-                double d = eps / _n;
-                double s = 2 * (Math.Atan(Math.Pow(_ro0 / ro, 1 / _n) * _tanS2) - S45);
-                double cs = Math.Cos(s);
-                double u = Math.Asin((_cosAzim * Math.Sin(s)) - (_sinAzim * cs * Math.Cos(d)));
-                double kau = _ka * Math.Pow(Math.Tan((u / 2.0) + S45), 1 / _alfa);
-                double deltav = Math.Asin((cs * Math.Sin(d)) / Math.Cos(u));
-                double lambda = -deltav / _alfa;
-                double phi = 0d;
-
-                // iteration calculation
-                for (int iter = MaximumIterations;;)
+                double fi1 = phi;
+                double esf = _e * Math.Sin(fi1);
+                phi = 2.0 * (Math.Atan(kau * Math.Pow((1.0 + esf) / (1.0 - esf), _e / 2.0)) - S45);
+                if (Math.Abs(fi1 - phi) <= IterationTolerance)
                 {
-                    double fi1 = phi;
-                    double esf = _e * Math.Sin(fi1);
-                    phi = 2.0 * (Math.Atan(kau * Math.Pow((1.0 + esf) / (1.0 - esf), _e / 2.0)) - S45);
-                    if (Math.Abs(fi1 - phi) <= IterationTolerance)
-                    {
-                        break;
-                    }
-
-                    if (--iter < 0)
-                    {
-                        break;
-                        //throw new ProjectionException(Errors.format(ErrorKeys.NO_CONVERGENCE));
-                    }
+                    break;
                 }
 
-                p[j] = lambda + central_meridian;
-                p[k] = phi;
+                if (--iter < 0)
+                {
+                    break;
+                    //throw new ProjectionException(Errors.format(ErrorKeys.NO_CONVERGENCE));
+                }
             }
 
+            return (
+                lon: lambda + central_meridian,
+                lat: phi,
+                z);
         }
 
         /// <summary>

--- a/ProjNet/CoordinateSystems/Transformations/ConcatenatedTransform.cs
+++ b/ProjNet/CoordinateSystems/Transformations/ConcatenatedTransform.cs
@@ -73,22 +73,31 @@ namespace ProjNet.CoordinateSystems.Transformations
             get { return _coordinateTransformationList[_coordinateTransformationList.Count-1].TargetCS.Dimension; }
         }
 
-        /// <summary>
-        /// Transforms a point
-        /// </summary>
-        /// <param name="point"></param>
-        /// <returns></returns>
-        public override double[] Transform(double[] point)
-		{
-            foreach (ICoordinateTransformation ct in _coordinateTransformationList)
-				point = ct.MathTransform.Transform(point);            
-			return point;			
-		}
-
-        protected internal override void Transform(ref Span<double> points, ref Span<double> altitudes)
+        public override (double x, double y, double z) Transform(double x, double y, double z)
         {
+            double[] xyzArr = null;
             foreach (ICoordinateTransformation ct in _coordinateTransformationList)
-                ((MathTransform)ct.MathTransform).Transform(ref points, ref altitudes);
+            {
+                if (ct.MathTransform is MathTransform ours)
+                {
+                    (x, y, z) = ours.Transform(x, y, z);
+                }
+                else
+                {
+                    if (xyzArr == null)
+                    {
+                        xyzArr = new double[3];
+                    }
+
+                    (xyzArr[0], xyzArr[1], xyzArr[2]) = (x, y, z);
+                    var transformed = ct.MathTransform.Transform(xyzArr);
+                    x = transformed?.Length > 0 ? transformed[0] : 0;
+                    y = transformed?.Length > 1 ? transformed[1] : 0;
+                    z = transformed?.Length > 2 ? transformed[2] : 0;
+                }
+            }
+
+            return (x, y, z);
         }
 
   //      /// <summary>

--- a/ProjNet/CoordinateSystems/Transformations/GeographicTransform.cs
+++ b/ProjNet/CoordinateSystems/Transformations/GeographicTransform.cs
@@ -105,16 +105,13 @@ namespace ProjNet.CoordinateSystems.Transformations
 			throw new NotImplementedException();
 		}
 
-        protected internal override void Transform(ref Span<double> points, ref Span<double> altitudes)
+        public override (double x, double y, double z) Transform(double x, double y, double z)
         {
-            int size = points.Length / 2;
-            for (int i = 0, j = 0; i < size; i++, j += 2)
-            {
-                points[j] /= SourceGCS.AngularUnit.RadiansPerUnit;
-                points[j] -= SourceGCS.PrimeMeridian.Longitude / SourceGCS.PrimeMeridian.AngularUnit.RadiansPerUnit;
-                points[j] += TargetGCS.PrimeMeridian.Longitude / TargetGCS.PrimeMeridian.AngularUnit.RadiansPerUnit;
-                points[j] *= SourceGCS.AngularUnit.RadiansPerUnit;
-            }
+            x /= SourceGCS.AngularUnit.RadiansPerUnit;
+            x -= SourceGCS.PrimeMeridian.Longitude / SourceGCS.PrimeMeridian.AngularUnit.RadiansPerUnit;
+            x += TargetGCS.PrimeMeridian.Longitude / TargetGCS.PrimeMeridian.AngularUnit.RadiansPerUnit;
+            x *= SourceGCS.AngularUnit.RadiansPerUnit;
+            return (x, y, z);
         }
 
         /*

--- a/ProjNet/CoordinateSystems/Transformations/MathTransform.cs
+++ b/ProjNet/CoordinateSystems/Transformations/MathTransform.cs
@@ -361,9 +361,9 @@ namespace ProjNet.CoordinateSystems.Transformations
                 bool hasZ = sequence.HasZ;
                 for (int i = 0; i < xys.Length; i++)
                 {
-                    xys[i].X = sequence.GetX(i);
-                    xys[i].Y = sequence.GetY(i);
-                    zs[i] = sequence.GetZ(i);
+                    xysArray[i].X = sequence.GetX(i);
+                    xysArray[i].Y = sequence.GetY(i);
+                    zsArray[i] = sequence.GetZ(i);
                 }
             }
 

--- a/ProjNet/CoordinateSystems/Transformations/PrimeMeridianTransform.cs
+++ b/ProjNet/CoordinateSystems/Transformations/PrimeMeridianTransform.cs
@@ -101,18 +101,21 @@ namespace ProjNet.CoordinateSystems.Transformations
         /// </summary>
         /// <param name="point"></param>
         /// <returns></returns>
-        protected internal override void Transform(ref Span<double> points, ref Span<double> altitudes)
+        public override (double x, double y, double z) Transform(double x, double y, double z)
         {
-            int size = points.Length / 2;
             if (!_isInverted)
             {
-                for (int i = 0, j = 0; i < size; i++, j+=2)
-                    points[j] = points[j] + _source.Longitude - _target.Longitude;
+                return (
+                    x: x + _source.Longitude - _target.Longitude,
+                    y,
+                    z);
             }
             else
             {
-                for (int i = 0, j = 0; i < size; i++, j += 2)
-                    points[j] = points[j] + _target.Longitude - _source.Longitude;
+                return (
+                    x: x + _target.Longitude - _source.Longitude,
+                    y,
+                    z);
             }
         }
 

--- a/ProjNet/ProjNET.csproj
+++ b/ProjNet/ProjNET.csproj
@@ -7,7 +7,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)scskey.snk</AssemblyOriginatorKeyFile>
-    <LangVersion>7.2</LangVersion>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <Import Project="$(SolutionDir)ProjNet.Common.props" />


### PR DESCRIPTION
- Base implementations now have virtual methods that can be overridden as appropriate to provide optimized versions for any of the following layouts:
    - `[x0, y0, z0, x1, y1, z1, ..., xn, yn, zn]`
    - `[x0, y0, x1, y1, ..., xn, yn, z0, z1, ..., zn]`
    - `[x0, x1, ..., xn, y0, y1, ..., yn, z0, z1, ..., zn]`

All built-in algorithms now only override the one-by-one variants.  The point of allowing subclasses to override for spans (and allowing different layouts) is to allow implementations that use SIMD and/or auxiliary DLLs for their implementations.  There ought not to be a **particularly** significant advantage to using spans the way we were doing before.