### PR TITLE
Fix Transverse_Mercator_South_Orientated

### DIFF
--- a/src/ProjNet/CoordinateSystems/Projections/ProjectionsRegistry.cs
+++ b/src/ProjNet/CoordinateSystems/Projections/ProjectionsRegistry.cs
@@ -28,6 +28,7 @@ namespace ProjNet.CoordinateSystems.Projections
             Register("google_mercator", typeof(PseudoMercator));
 			
             Register("transverse_mercator", typeof(TransverseMercator));
+            Register("transverse_mercator_south_orientated", typeof(TransverseMercator));
 
             Register("albers", typeof(AlbersProjection));
 			Register("albers_conic_equal_area", typeof(AlbersProjection));

--- a/test/ProjNet.Tests/WKT/WKTCoordSysParserTests.cs
+++ b/test/ProjNet.Tests/WKT/WKTCoordSysParserTests.cs
@@ -159,7 +159,7 @@ namespace ProjNET.Tests.WKT
                                 {
                                     //Skip not supported projections
                                     case "Oblique_Stereographic":
-                                    case "Transverse_Mercator_South_Orientated":
+                                //    case "Transverse_Mercator_South_Orientated":
                                     case "Lambert_Conformal_Conic_1SP":
                                     case "Lambert_Azimuthal_Equal_Area":
                                     case "Tunisia_Mining_Grid":


### PR DESCRIPTION
`Transverse_Mercator_South_Orientated` works correctly using standard `Transverse_Mercator` and the WKT / EPSG defintions in postgis and csv. This has been verified for LO15->LO33 projections in South Africa (EPSG 2046 -> 2055) and (22234-22293)