### PR TITLE
CoordinateSystem.WKT creates WKT that can't be parsed 

### DIFF
--- a/src/ProjNet/IO/CoordinateSystems/CoordinateSystemWktReader.cs
+++ b/src/ProjNet/IO/CoordinateSystems/CoordinateSystemWktReader.cs
@@ -298,9 +298,18 @@ namespace ProjNet.IO.CoordinateSystems
                 tokenizer.NextToken();
                 double paramValue = tokenizer.GetNumericValue();
                 tokenizer.ReadToken("]");
-                tokenizer.ReadToken(",");
                 paramList.Add(new ProjectionParameter(paramName, paramValue));
+                //tokenizer.ReadToken(",");
+                //tokenizer.NextToken();
                 tokenizer.NextToken();
+                if (tokenizer.GetStringValue() == ",")
+                {
+                    tokenizer.NextToken();
+                }
+                else
+                {
+                    break;
+                }
             }
             var projection = new Projection(projectionName, paramList, projectionName, authority, authorityCode, string.Empty, string.Empty, string.Empty);
             return projection;

--- a/test/ProjNet.Tests/WKT/WKTCoordSysParserTests.cs
+++ b/test/ProjNet.Tests/WKT/WKTCoordSysParserTests.cs
@@ -419,6 +419,33 @@ namespace ProjNET.Tests.WKT
             Assert.That(fcs.AuthorityCode, Is.EqualTo(5250L));
         }
 
+        [Test]
+        public void ParseWktCreatedByCoordinateSystem()
+        {
+            // Sample WKT from an external source.
+            string sampleWKT =
+                "PROJCS[\"\", " +
+                  "GEOGCS[\"\", " +
+                    "DATUM[\"\", " +
+                      "SPHEROID[\"GRS_1980\", 6378137, 298.2572221010042] " +
+                    "], " +
+                  "PRIMEM[\"Greenwich\", 0], " +
+                  "UNIT[\"Degree\", 0.017453292519943295]" +
+                  "], " +
+                  "PROJECTION[\"Transverse_Mercator\"], " +
+                  "PARAMETER[\"False_Easting\", 500000], " +
+                  "PARAMETER[\"False_Northing\", 0], " +
+                  "PARAMETER[\"Central_Meridian\", -75], " +
+                  "PARAMETER[\"Scale_Factor\", 0.9996], " +
+                  "UNIT[\"Meter\", 1]" +
+                  "]";
+
+            var csFromSample = (CoordinateSystem)ProjNet.IO.CoordinateSystems.CoordinateSystemWktReader.Parse(sampleWKT);  // does not throw
+            string wktFromProjNetCS = csFromSample.WKT;
+            var csFromProjNetGeneratedWKT = (CoordinateSystem)ProjNet.IO.CoordinateSystems.CoordinateSystemWktReader.Parse(wktFromProjNetCS);  // throws
+        }
+
+
         #region Utility
 
         private bool CheckPrimem(PrimeMeridian primeMeridian, string name, double? longitude, string authority, long? code)


### PR DESCRIPTION
Add a failing test case to replicate the issue described in #76 .