### PR TITLE
Upgrade to dotnet 8.0.302

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,3 +188,6 @@ FakesAssemblies/
 /packages
 **/BenchmarkDotNet*/
 /ProjNet/CoordinateSystems/Transformations/MathTransformFactory.cs
+
+# Jetbrains Rider
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,17 @@
 language: csharp
 mono: none
 sudo: false
-dotnet: 8.0.6
+dotnet: 8.0.302
 dist: bionic
 
+before_install:
+  # explicitly install other targeted SDKs side by side
+  - sudo apt-get install dotnet-sdk-3.1
 
 script:
   - dotnet build -c Release
-  - dotnet test  -c Release --no-build
+  - dotnet test  -c Release --no-build -f netcoreapp3.1
+  - dotnet test  -c Release --no-build -f net8.0
   - dotnet pack  -c Release --no-build -p:NoWarn=NU5105
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: csharp
 mono: none
 sudo: false
-dotnet: 3.1
+dotnet: 8.0.6
 dist: bionic
 
 

--- a/src/ProjNet.Benchmark/ProjNet.Benchmark.csproj
+++ b/src/ProjNet.Benchmark/ProjNet.Benchmark.csproj
@@ -2,11 +2,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>1701;1702;1591</NoWarn>
 
     <IsPackable>false</IsPackable>
+
+    <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ProjNet.Benchmark/ProjNet.Benchmark.csproj
+++ b/src/ProjNet.Benchmark/ProjNet.Benchmark.csproj
@@ -6,7 +6,10 @@
 
     <IsPackable>false</IsPackable>
 
-    <TargetFrameworks>netcoreapp3.1;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0;</TargetFrameworks>
+
+    <OutputType>Exe</OutputType>
+
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ProjNet.Benchmark/ProjNet.Benchmark.csproj
+++ b/src/ProjNet.Benchmark/ProjNet.Benchmark.csproj
@@ -6,7 +6,7 @@
 
     <IsPackable>false</IsPackable>
 
-    <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ProjNet.Benchmark/ProjNet.Benchmark.csproj
+++ b/src/ProjNet.Benchmark/ProjNet.Benchmark.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>1701;1702;1591</NoWarn>
 
     <IsPackable>false</IsPackable>

--- a/src/ProjNet/CoordinateSystemServices.cs
+++ b/src/ProjNet/CoordinateSystemServices.cs
@@ -5,7 +5,7 @@
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation; either version 2 of the License, or
 // (at your option) any later version.
-// 
+//
 // ProjNet is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -13,8 +13,8 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with SharpMap; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA 
-    
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -45,16 +45,17 @@ namespace ProjNet
 
         private readonly CoordinateSystemFactory _coordinateSystemFactory;
         private readonly CoordinateTransformationFactory _ctFactory;
-        
+
         private readonly ManualResetEvent _initialization = new ManualResetEvent(false);
 
         #region CsEqualityComparer class
+
         private class CsEqualityComparer : EqualityComparer<IInfo>
         {
             public override bool Equals(IInfo x, IInfo y)
             {
                 return x.AuthorityCode == y.AuthorityCode &&
-                    string.Compare(x.Authority, y.Authority, StringComparison.OrdinalIgnoreCase) == 0;
+                       string.Compare(x.Authority, y.Authority, StringComparison.OrdinalIgnoreCase) == 0;
             }
 
             public override int GetHashCode(IInfo obj)
@@ -63,6 +64,7 @@ namespace ProjNet
                 return Convert.ToInt32(obj.AuthorityCode) + (obj.Authority != null ? obj.Authority.GetHashCode() : 0);
             }
         }
+
         #endregion
 
         #region CoordinateSystemKey class
@@ -80,14 +82,38 @@ namespace ProjNet
                 throw new NotSupportedException();
             }
 
-            public string Name { get { return null; } }
+            public string Name
+            {
+                get { return null; }
+            }
+
             public string Authority { get; private set; }
             public long AuthorityCode { get; private set; }
-            public string Alias { get { return null; } }
-            public string Abbreviation { get { return null; } }
-            public string Remarks { get { return null; } }
-            public string WKT { get { return null; } }
-            public string XML { get { return null; } }
+
+            public string Alias
+            {
+                get { return null; }
+            }
+
+            public string Abbreviation
+            {
+                get { return null; }
+            }
+
+            public string Remarks
+            {
+                get { return null; }
+            }
+
+            public string WKT
+            {
+                get { return null; }
+            }
+
+            public string XML
+            {
+                get { return null; }
+            }
         }
 
         #endregion
@@ -124,7 +150,7 @@ namespace ProjNet
         /*
         public static string GetFromSpatialReferenceOrg(string authority, long code)
         {
-            var url = string.Format("http://spatialreference.org/ref/{0}/{1}/ogcwkt/", 
+            var url = string.Format("http://spatialreference.org/ref/{0}/{1}/ogcwkt/",
                 authority.ToLowerInvariant(),
                 code);
             var req = (HttpWebRequest) WebRequest.Create(url);
@@ -164,9 +190,9 @@ namespace ProjNet
             _csBySrid = new Dictionary<int, CoordinateSystem>();
             _sridByCs = new Dictionary<IInfo, int>(new CsEqualityComparer());
 
-            object enumObj = (object)enumeration ?? DefaultInitialization();
+            object enumObj = (object) enumeration ?? DefaultInitialization();
             _initialization = new ManualResetEvent(false);
-            System.Threading.Tasks.Task.Run(() => FromEnumeration((new[] { this, enumObj })));
+            System.Threading.Tasks.Task.Run(() => FromEnumeration((new[] {this, enumObj})));
         }
 
         //private CoordinateSystemServices(ICoordinateSystemFactory coordinateSystemFactory,
@@ -179,7 +205,8 @@ namespace ProjNet
         //    ThreadPool.QueueUserWorkItem(FromEnumeration, new[] { this, enumObj });
         //}
 
-        private static CoordinateSystem CreateCoordinateSystem(CoordinateSystemFactory coordinateSystemFactory, string wkt)
+        private static CoordinateSystem CreateCoordinateSystem(CoordinateSystemFactory coordinateSystemFactory,
+            string wkt)
         {
             try
             {
@@ -233,7 +260,7 @@ namespace ProjNet
             if (paras[1] is IEnumerable<KeyValuePair<int, string>>)
                 FromEnumeration(css, (IEnumerable<KeyValuePair<int, string>>) paras[1]);
             else
-                FromEnumeration(css, (IEnumerable<KeyValuePair<int, CoordinateSystem>>)paras[1]);
+                FromEnumeration(css, (IEnumerable<KeyValuePair<int, CoordinateSystem>>) paras[1]);
 
             css._initialization.Set();
         }
@@ -305,6 +332,11 @@ namespace ProjNet
             return _ctFactory.CreateFromCoordinateSystems(source, target);
         }
 
+        /// <summary>
+        /// AddCoordinateSystem
+        /// </summary>
+        /// <param name="srid"></param>
+        /// <param name="coordinateSystem"></param>
         protected void AddCoordinateSystem(int srid, CoordinateSystem coordinateSystem)
         {
             lock (((IDictionary) _csBySrid).SyncRoot)
@@ -332,6 +364,11 @@ namespace ProjNet
             }
         }
 
+        /// <summary>
+        /// AddCoordinateSystem
+        /// </summary>
+        /// <param name="coordinateSystem"></param>
+        /// <returns></returns>
         protected virtual int AddCoordinateSystem(CoordinateSystem coordinateSystem)
         {
             int srid = (int) coordinateSystem.AuthorityCode;
@@ -340,11 +377,17 @@ namespace ProjNet
             return srid;
         }
 
+        /// <summary>
+        /// Clear
+        /// </summary>
         protected void Clear()
         {
             _csBySrid.Clear();
         }
 
+        /// <summary>
+        /// Count property
+        /// </summary>
         protected int Count
         {
             get
@@ -354,11 +397,21 @@ namespace ProjNet
             }
         }
 
+        /// <summary>
+        /// RemoveCoordinateSystem
+        /// </summary>
+        /// <param name="srid"></param>
+        /// <returns></returns>
+        /// <exception cref="NotSupportedException"></exception>
         public bool RemoveCoordinateSystem(int srid)
         {
             throw new NotSupportedException();
         }
 
+        /// <summary>
+        /// GetEnumerator
+        /// </summary>
+        /// <returns></returns>
         public IEnumerator<KeyValuePair<int, CoordinateSystem>> GetEnumerator()
         {
             _initialization.WaitOne();

--- a/src/ProjNet/CoordinateSystems/CoordinateSystemFactory.cs
+++ b/src/ProjNet/CoordinateSystems/CoordinateSystemFactory.cs
@@ -5,7 +5,7 @@
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation; either version 2 of the License, or
 // (at your option) any later version.
-// 
+//
 // ProjNet is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -13,7 +13,7 @@
 
 // You should have received a copy of the GNU Lesser General Public License
 // along with ProjNet; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA 
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 using System;
 using System.Collections.Generic;
@@ -26,18 +26,15 @@ namespace ProjNet.CoordinateSystems
     /// Builds up complex objects from simpler objects or values.
     /// </summary>
     /// <remarks>
-    /// <para>CoordinateSystemFactory allows applications to make coordinate systems that 
-    /// cannot be created by a <see cref="CoordinateSystemAuthorityFactory"/>. This factory is very 
-    /// flexible, whereas the authority factory is easier to use.</para>
-    /// <para>So <see cref="ICoordinateSystemAuthorityFactory"/>can be used to make 'standard' coordinate 
-    /// systems, and <see cref="CoordinateSystemFactory"/> can be used to make 'special' 
-    /// coordinate systems.</para>
-    /// <para>For example, the EPSG authority has codes for USA state plane coordinate systems 
-    /// using the NAD83 datum, but these coordinate systems always use meters. EPSG does not 
+    /// <para>CoordinateSystemFactory allows applications to make coordinate systems that
+    /// cannot be created by a simpler implementation . This factory is very
+    /// flexible, whereas other implementations are easier to use.</para>
+    /// <para>For example, the EPSG authority has codes for USA state plane coordinate systems
+    /// using the NAD83 datum, but these coordinate systems always use meters. EPSG does not
     /// have codes for NAD83 state plane coordinate systems that use feet units. This factory
     /// lets an application create such a hybrid coordinate system.</para>
     /// </remarks>
-    public class CoordinateSystemFactory 
+    public class CoordinateSystemFactory
     {
         /// <summary>
         /// Creates an instance of this class
@@ -86,11 +83,11 @@ namespace ProjNet.CoordinateSystems
         /// <summary>
         /// Creates a <see cref="FittedCoordinateSystem"/>.
         /// </summary>
-        /// <remarks>The units of the axes in the fitted coordinate system will be 
+        /// <remarks>The units of the axes in the fitted coordinate system will be
         /// inferred from the units of the base coordinate system. If the affine map
         /// performs a rotation, then any mixed axes must have identical units. For
-        /// example, a (lat_deg,lon_deg,height_feet) system can be rotated in the 
-        /// (lat,lon) plane, since both affected axes are in degrees. But you 
+        /// example, a (lat_deg,lon_deg,height_feet) system can be rotated in the
+        /// (lat,lon) plane, since both affected axes are in degrees. But you
         /// should not rotate this coordinate system in any other plane.</remarks>
         /// <param name="name">Name of coordinate system</param>
         /// <param name="baseCoordinateSystem">Base coordinate system</param>
@@ -125,9 +122,9 @@ namespace ProjNet.CoordinateSystems
         /// Creates a <see cref="ILocalCoordinateSystem">local coordinate system</see>.
         /// </summary>
         /// <remarks>
-        ///  The dimension of the local coordinate system is determined by the size of 
-        /// the axis array. All the axes will have the same units. If you want to make 
-        /// a coordinate system with mixed units, then you can make a compound 
+        ///  The dimension of the local coordinate system is determined by the size of
+        /// the axis array. All the axes will have the same units. If you want to make
+        /// a coordinate system with mixed units, then you can make a compound
         /// coordinate system from different local coordinate systems.
         /// </remarks>
         /// <param name="name">Name of local coordinate system</param>
@@ -222,9 +219,9 @@ namespace ProjNet.CoordinateSystems
         /// Creates <see cref="HorizontalDatum"/> from ellipsoid and Bursa-World parameters.
         /// </summary>
         /// <remarks>
-        /// Since this method contains a set of Bursa-Wolf parameters, the created 
+        /// Since this method contains a set of Bursa-Wolf parameters, the created
         /// datum will always have a relationship to WGS84. If you wish to create a
-        /// horizontal datum that has no relationship with WGS84, then you can 
+        /// horizontal datum that has no relationship with WGS84, then you can
         /// either specify a <see cref="DatumType">horizontalDatumType</see> of <see cref="DatumType.HD_Other"/>, or create it via WKT.
         /// </remarks>
         /// <param name="name">Name of ellipsoid</param>
@@ -297,7 +294,7 @@ namespace ProjNet.CoordinateSystems
         /// </summary>
         /// <param name="name">Name of datum</param>
         /// <param name="datumType">Type of datum</param>
-        /// <returns>Vertical datum</returns>	
+        /// <returns>Vertical datum</returns>
         public VerticalDatum CreateVerticalDatum(string name, DatumType datumType)
         {
             if (string.IsNullOrWhiteSpace(name))
@@ -325,7 +322,7 @@ namespace ProjNet.CoordinateSystems
         }
 
         /// <summary>
-        /// Creates a <see cref="CreateGeocentricCoordinateSystem"/> from a <see cref="HorizontalDatum">datum</see>, 
+        /// Creates a <see cref="CreateGeocentricCoordinateSystem"/> from a <see cref="HorizontalDatum">datum</see>,
         /// <see cref="LinearUnit">linear unit</see> and <see cref="PrimeMeridian"/>.
         /// </summary>
         /// <param name="name">Name of geocentric coordinate system</param>

--- a/src/ProjNet/CoordinateSystems/Info.cs
+++ b/src/ProjNet/CoordinateSystems/Info.cs
@@ -5,7 +5,7 @@
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation; either version 2 of the License, or
 // (at your option) any later version.
-// 
+//
 // ProjNet is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -13,7 +13,7 @@
 
 // You should have received a copy of the GNU Lesser General Public License
 // along with ProjNet; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA 
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 using System;
 using System.Text;
@@ -24,23 +24,23 @@ namespace ProjNet.CoordinateSystems
 	/// The Info object defines the standard information
 	/// stored with spatial reference objects
     /// </summary>
-    [Serializable] 
+    [Serializable]
     public abstract class Info : IInfo
 	{
 		/// <summary>
 		/// A base interface for metadata applicable to coordinate system objects.
 		/// </summary>
 		/// <remarks>
-		/// <para>The metadata items ‘Abbreviation’, ‘Alias’, ‘Authority’, ‘AuthorityCode’, ‘Name’ and ‘Remarks’ 
+		/// <para>The metadata items ï¿½Abbreviationï¿½, ï¿½Aliasï¿½, ï¿½Authorityï¿½, ï¿½AuthorityCodeï¿½, ï¿½Nameï¿½ and ï¿½Remarksï¿½
 		/// were specified in the Simple Features interfaces, so they have been kept here.</para>
-		/// <para>This specification does not dictate what the contents of these items 
+		/// <para>This specification does not dictate what the contents of these items
 		/// should be. However, the following guidelines are suggested:</para>
-		/// <para>When <see cref="ICoordinateSystemAuthorityFactory"/> is used to create an object, the ‘Authority’
-		/// and 'AuthorityCode' values should be set to the authority name of the factory object, and the authority 
-		/// code supplied by the client, respectively. The other values may or may not be set. (If the authority is 
+		/// <para>When ICoordinateSystemAuthorityFactory is used to create an object, the ï¿½Authorityï¿½
+		/// and 'AuthorityCode' values should be set to the authority name of the factory object, and the authority
+		/// code supplied by the client, respectively. The other values may or may not be set. (If the authority is
 		/// EPSG, the implementer may consider using the corresponding metadata values in the EPSG tables.)</para>
 		/// <para>When <see cref="CoordinateSystemFactory"/> creates an object, the 'Name' should be set to the value
-		/// supplied by the client. All of the other metadata items should be left empty</para>
+		/// supplied by the client. All the other metadata items should be left empty</para>
 		/// </remarks>
 		/// <param name="name">Name</param>
 		/// <param name="authority">Authority name</param>
@@ -49,11 +49,11 @@ namespace ProjNet.CoordinateSystems
 		/// <param name="abbreviation">Abbreviation</param>
 		/// <param name="remarks">Provider-supplied remarks</param>
 		internal Info(
-						string name, 
-						string authority, 
-						long code, 
-						string alias, 
-						string abbreviation, 
+						string name,
+						string authority,
+						long code,
+						string alias,
+						string abbreviation,
 						string remarks)
 		{
 			_Name = name;
@@ -142,13 +142,13 @@ namespace ProjNet.CoordinateSystems
 		{
 			return WKT;
 		}
-		
+
 		/// <summary>
 		/// Returns the Well-known text for this object
 		/// as defined in the simple features specification.
 		/// </summary>
 		public abstract string WKT {get ;}
-		
+
 		/// <summary>
 		/// Gets an XML representation of this object.
 		/// </summary>

--- a/src/ProjNet/CoordinateSystems/Projection.cs
+++ b/src/ProjNet/CoordinateSystems/Projection.cs
@@ -5,7 +5,7 @@
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation; either version 2 of the License, or
 // (at your option) any later version.
-// 
+//
 // ProjNet is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -13,7 +13,7 @@
 
 // You should have received a copy of the GNU Lesser General Public License
 // along with ProjNet; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA 
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 using System;
 using System.Collections.Generic;
@@ -30,11 +30,11 @@ namespace ProjNet.CoordinateSystems
 	/// interest, e.g., Transverse Mercator, Lambert, will be implemented as a class of
 	/// type Projection, supporting the IProjection interface.
     /// </summary>
-    [Serializable] 
+    [Serializable]
     public class Projection : Info, IProjection
 	{
 		internal Projection(string className, List<ProjectionParameter> parameters,
-			string name, string authority, long code, string alias, 
+			string name, string authority, long code, string alias,
 			string remarks, string abbreviation)
 			: base(name, authority, code, alias, abbreviation, remarks)
 		{
@@ -84,12 +84,12 @@ namespace ProjNet.CoordinateSystems
 		/// <returns>parameter or null if not found</returns>
 		public ProjectionParameter GetParameter(string name)
 		{
-			foreach (ProjectionParameter par in _parameters)
+			foreach (var par in _parameters)
 				if (par.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
 					return par;
 			return null;
 		}
-				
+
 		private string _ClassName;
 
 		/// <summary>
@@ -108,7 +108,7 @@ namespace ProjNet.CoordinateSystems
 		{
 			get
 			{
-				StringBuilder sb = new StringBuilder();
+				var sb = new StringBuilder();
 				sb.AppendFormat("PROJECTION[\"{0}\"", ClassName);
 				if (!string.IsNullOrWhiteSpace(Authority) && AuthorityCode > 0)
 					sb.AppendFormat(", AUTHORITY[\"{0}\", \"{1}\"]", Authority, AuthorityCode);
@@ -124,9 +124,9 @@ namespace ProjNet.CoordinateSystems
 		{
 			get
 			{
-				StringBuilder sb = new StringBuilder();
+				var sb = new StringBuilder();
 				sb.AppendFormat(CultureInfo.InvariantCulture.NumberFormat, "<CS_Projection Classname=\"{0}\">{1}", ClassName, InfoXml);
-				foreach (ProjectionParameter param in Parameters)
+				foreach (var param in Parameters)
 					sb.Append(param.XML);
 				sb.Append("</CS_Projection>");
 				return sb.ToString();
@@ -144,12 +144,12 @@ namespace ProjNet.CoordinateSystems
 		{
 			if (!(obj is Projection))
 				return false;
-			Projection proj = obj as Projection;
+			var proj = obj as Projection;
 			if (proj.NumParameters != this.NumParameters)
 				return false;
 			for (int i = 0; i < _parameters.Count; i++)
 			{
-				ProjectionParameter param = GetParameter(proj.GetParameter(i).Name);
+				var param = GetParameter(proj.GetParameter(i).Name);
 				if (param == null)
 					return false;
 				if (param.Value != proj.GetParameter(i).Value)

--- a/src/ProjNet/CoordinateSystems/Projections/MapProjection.cs
+++ b/src/ProjNet/CoordinateSystems/Projections/MapProjection.cs
@@ -5,7 +5,7 @@
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation; either version 2 of the License, or
 // (at your option) any later version.
-// 
+//
 // ProjNet is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -13,11 +13,11 @@
 
 // You should have received a copy of the GNU Lesser General Public License
 // along with ProjNet; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA 
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 // SOURCECODE IS MODIFIED FROM ANOTHER WORK AND IS ORIGINALLY BASED ON GeoTools.NET:
 /*
- *  Copyright (C) 2002 Urban Science Applications, Inc. 
+ *  Copyright (C) 2002 Urban Science Applications, Inc.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
@@ -49,13 +49,22 @@ namespace ProjNet.CoordinateSystems.Projections
     [Serializable]
     public abstract class MapProjection : MathTransform, IProjection
     {
+        // ReSharper disable InconsistentNaming
+        /// <summary>
+        /// EPS10 set to 1e-10
+        /// </summary>
         protected const double EPS10 = 1e-10;
 
+        /// <summary>
+        /// EPS7 set to 1e-7
+        /// </summary>
         protected const double EPS7 = 1e-7;
 
+        /// <summary>
+        /// HUGE_VAL set to double.NaN.
+        /// </summary>
         protected const double HUGE_VAL = double.NaN;
 
-        // ReSharper disable InconsistentNaming
         /// <summary>
         /// Eccentricity
         /// </summary>
@@ -224,7 +233,7 @@ namespace ProjNet.CoordinateSystems.Projections
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="index"></param>
         /// <returns></returns>
@@ -245,7 +254,7 @@ namespace ProjNet.CoordinateSystems.Projections
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public int NumParameters
         {
@@ -630,7 +639,7 @@ namespace ProjNet.CoordinateSystems.Projections
             /*
             if (proj.NumParameters != NumParameters)
 				return false;
-			
+
             for (var i = 0; i < _Parameters.Count; i++)
 			{
 				var param = _Parameters.Find(par => par.Name.Equals(proj.GetParameter(i).Name, StringComparison.OrdinalIgnoreCase));
@@ -714,7 +723,7 @@ namespace ProjNet.CoordinateSystems.Projections
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="A"></param>
         /// <param name="B"></param>
@@ -725,7 +734,7 @@ namespace ProjNet.CoordinateSystems.Projections
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="A"></param>
         /// <param name="B"></param>
@@ -758,7 +767,7 @@ namespace ProjNet.CoordinateSystems.Projections
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="x"></param>
         /// <returns></returns>
@@ -805,8 +814,8 @@ namespace ProjNet.CoordinateSystems.Projections
         }
 
         /// <summary>
-        /// Function to compute constant small q which is the radius of a 
-        /// parallel of latitude, phi, divided by the semimajor axis. 
+        /// Function to compute constant small q which is the radius of a
+        /// parallel of latitude, phi, divided by the semimajor axis.
         /// </summary>
         protected static double qsfnz(double sinphi, double eccent)
         {
@@ -821,8 +830,8 @@ namespace ProjNet.CoordinateSystems.Projections
         }
 
         /// <summary>
-        /// Function to compute constant small q which is the radius of a 
-        /// parallel of latitude, phi, divided by the semimajor axis. 
+        /// Function to compute constant small q which is the radius of a
+        /// parallel of latitude, phi, divided by the semimajor axis.
         /// </summary>
         protected static double qsfn(double sinphi, double eccent, double one_es)
         {
@@ -871,8 +880,8 @@ namespace ProjNet.CoordinateSystems.Projections
         }
 
         /// <summary>
-        /// 
-        /// 
+        ///
+        ///
         /// </summary>
         /// <param name="eccent"></param>
         /// <param name="qs"></param>
@@ -979,7 +988,7 @@ namespace ProjNet.CoordinateSystems.Projections
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="x"></param>
         /// <returns></returns>
@@ -989,7 +998,7 @@ namespace ProjNet.CoordinateSystems.Projections
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="x"></param>
         /// <returns></returns>
@@ -999,7 +1008,7 @@ namespace ProjNet.CoordinateSystems.Projections
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="x"></param>
         /// <returns></returns>
@@ -1032,8 +1041,8 @@ namespace ProjNet.CoordinateSystems.Projections
         }
 
         /// <summary>
-        /// Calculates the meridian distance. This is the distance along the central 
-        /// meridian from the equator to <paramref name="phi"/>. Accurate to &lt; 1e-5 meters 
+        /// Calculates the meridian distance. This is the distance along the central
+        /// meridian from the equator to <paramref name="phi"/>. Accurate to &lt; 1e-5 meters
         /// when used in conjuction with typical major axis values.
         /// </summary>
         /// <param name="phi"></param>
@@ -1154,6 +1163,11 @@ namespace ProjNet.CoordinateSystems.Projections
         private const double P20 = 0.01677689594356261023; /* 761 / 45360 */
 
 
+        /// <summary>
+        /// authset
+        /// </summary>
+        /// <param name="es"></param>
+        /// <returns></returns>
         protected static double[] authset(double es)
         {
             double[] APA = new double[3];
@@ -1169,6 +1183,12 @@ namespace ProjNet.CoordinateSystems.Projections
             return APA;
         }
 
+        /// <summary>
+        /// authlat
+        /// </summary>
+        /// <param name="beta"></param>
+        /// <param name="APA"></param>
+        /// <returns></returns>
         protected static double authlat(double beta, double[] APA)
         {
             double t = beta + beta;

--- a/src/ProjNet/CoordinateSystems/Projections/PolarStereographicProjection.cs
+++ b/src/ProjNet/CoordinateSystems/Projections/PolarStereographicProjection.cs
@@ -214,5 +214,6 @@ namespace ProjNet.CoordinateSystems.Projections
             double t = (sinphi > 0.0) ? cosphi / (1.0 + sinphi) : (1.0 - sinphi) / cosphi;
             return Math.Exp(e * Math.Atanh(e * sinphi)) * t;
         }
+
     }
 }

--- a/src/ProjNet/CoordinateSystems/Projections/PolarStereographicProjection.cs
+++ b/src/ProjNet/CoordinateSystems/Projections/PolarStereographicProjection.cs
@@ -212,7 +212,21 @@ namespace ProjNet.CoordinateSystems.Projections
         private double tsfn(double cosphi, double sinphi, double e)
         {
             double t = (sinphi > 0.0) ? cosphi / (1.0 + sinphi) : (1.0 - sinphi) / cosphi;
-            return Math.Exp(e * Math.Atanh(e * sinphi)) * t;
+            return Math.Exp(e * Atanh(e * sinphi)) * t;
+        }
+
+        /// <summary>
+        /// Atanh - Inverse of Math.Tanh
+        /// </summary>
+        /// <remarks>The Math.Atanh is not available for netstandard2.0 which we still need to support.</remarks>
+        /// <param name="x"></param>
+        private static double Atanh(double x)
+        {
+            #if NETSTANDARD2_0
+                return (Math.Log(1 + x) - Math.Log(1 - x)) / 2;
+            #else
+                return Math.Atanh(x);
+            #endif
         }
 
     }

--- a/src/ProjNet/CoordinateSystems/Projections/ProjectionParameterSet.cs
+++ b/src/ProjNet/CoordinateSystems/Projections/ProjectionParameterSet.cs
@@ -8,7 +8,7 @@ namespace ProjNet.CoordinateSystems.Projections
     /// A set of projection parameters
     /// </summary>
     // TODO: KeyedCollection<string, double>
-    [Serializable] 
+    [Serializable]
     public class ProjectionParameterSet : Dictionary<string, double>, IEquatable<ProjectionParameterSet>
     {
         private readonly Dictionary<string, string> _originalNames = new Dictionary<string, string>();
@@ -16,8 +16,16 @@ namespace ProjNet.CoordinateSystems.Projections
         /// <summary>
         /// Needed for serialzation
         /// </summary>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code")]
         public ProjectionParameterSet(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
             :base(info, context)
+        {}
+
+        /// <summary>
+        /// Default constructor needed for JSon (De)Serialization.
+        /// </summary>
+        public ProjectionParameterSet()
+            : this(new List<ProjectionParameter>())
         {}
 
         /// <summary>
@@ -34,7 +42,7 @@ namespace ProjNet.CoordinateSystems.Projections
                 Add(key, pp.Value);
             }
         }
-        
+
         /// <summary>
         /// Function to create an enumeration of <see cref="ProjectionParameter"/>s of the content of this projection parameter set.
         /// </summary>

--- a/src/ProjNet/CoordinateSystems/Transformations/GeographicTransform.cs
+++ b/src/ProjNet/CoordinateSystems/Transformations/GeographicTransform.cs
@@ -5,7 +5,7 @@
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation; either version 2 of the License, or
 // (at your option) any later version.
-// 
+//
 // ProjNet is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -13,7 +13,7 @@
 
 // You should have received a copy of the GNU Lesser General Public License
 // along with ProjNet; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA 
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 using System;
 
@@ -23,7 +23,7 @@ namespace ProjNet.CoordinateSystems.Transformations
 	/// The GeographicTransform class is implemented on geographic transformation objects and
 	/// implements datum transformations between geographic coordinate systems.
     /// </summary>
-    [Serializable] 
+    [Serializable]
     public class GeographicTransform : MathTransform
 	{
 		internal GeographicTransform(GeographicCoordinateSystem sourceGCS, GeographicCoordinateSystem targetGCS)
@@ -65,16 +65,22 @@ namespace ProjNet.CoordinateSystems.Transformations
 			}
 		}
 
+        /// <summary>
+        /// DimSource
+        /// </summary>
         public override int DimSource
         {
             get { return SourceGCS.Dimension; }
         }
 
+        /// <summary>
+        /// DimTarget
+        /// </summary>
         public override int DimTarget
         {
             get { return TargetGCS.Dimension; }
         }
-        
+
         /// <summary>
 		/// Creates the inverse transform of this object.
 		/// </summary>

--- a/src/ProjNet/CoordinateSystems/VerticalDatum.cs
+++ b/src/ProjNet/CoordinateSystems/VerticalDatum.cs
@@ -24,6 +24,9 @@ namespace ProjNet.CoordinateSystems
         {
         }
 
+        /// <summary>
+        /// Creates a new "Ordnance Datum Newlyn" (EPSG::5101)
+        /// </summary>
         public static VerticalDatum ODN
         {
             get

--- a/src/ProjNet/ProjNET.csproj
+++ b/src/ProjNet/ProjNET.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>ProjNet</RootNamespace>
     <SignAssembly>true</SignAssembly>
     <EnableApiCompat>true</EnableApiCompat>
-    <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Label="Assembly Info">

--- a/src/ProjNet/ProjNET.csproj
+++ b/src/ProjNet/ProjNET.csproj
@@ -3,9 +3,9 @@
 
   <PropertyGroup>
     <RootNamespace>ProjNet</RootNamespace>
-    <TargetFramework>netstandard2.0</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <EnableApiCompat>true</EnableApiCompat>
+    <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Label="Assembly Info">
@@ -30,7 +30,6 @@ Proj.NET performs point-to-point coordinate conversions between geodetic coordin
   </ItemGroup>
 
 	<ItemGroup Condition=" '$(EnableApiCompat)' == 'true' ">
-		<PackageReference Include="Microsoft.DotNet.ApiCompat" Version="6.0.0-beta.21159.11" PrivateAssets="All" />
 		<PackageDownload Include="ProjNet" Version="[2.0.0]" PrivateAssets="All" />
 
 		<ResolvedMatchingContract Include="$(NugetPackageRoot)projnet\2.0.0\lib\netstandard2.0\ProjNET.dll" />

--- a/src/ProjNet/ProjNET.csproj
+++ b/src/ProjNet/ProjNET.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>ProjNet</RootNamespace>
     <SignAssembly>true</SignAssembly>
     <EnableApiCompat>true</EnableApiCompat>
-    <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Label="Assembly Info">

--- a/test/ProjNet.Tests/CoordinateSystemServicesTest.cs
+++ b/test/ProjNet.Tests/CoordinateSystemServicesTest.cs
@@ -88,7 +88,7 @@ namespace ProjNET.Tests
                 var sridElement = node.Element("SRID");
                 if (sridElement != null)
                 {
-                    var srid = int.Parse(sridElement.Value);
+                    int srid = int.Parse(sridElement.Value);
                     yield return new KeyValuePair<int, string>(srid, node.LastNode.ToString());
                 }
             }

--- a/test/ProjNet.Tests/ProjNET.Tests.csproj
+++ b/test/ProjNet.Tests/ProjNET.Tests.csproj
@@ -5,7 +5,7 @@
     <SignAssembly>true</SignAssembly>
     <NoWarn>1701;1702;1591</NoWarn>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net6;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/ProjNet.Tests/ProjNET.Tests.csproj
+++ b/test/ProjNet.Tests/ProjNET.Tests.csproj
@@ -5,7 +5,7 @@
     <SignAssembly>true</SignAssembly>
     <NoWarn>1701;1702;1591</NoWarn>
     <OutputType>Library</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/ProjNet.Tests/ProjNET.Tests.csproj
+++ b/test/ProjNet.Tests/ProjNET.Tests.csproj
@@ -2,14 +2,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <NoWarn>1701;1702;1591</NoWarn>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Npgsql" Version="8.0.3" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Update="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/ProjNet.Tests/ProjNET.Tests.csproj
+++ b/test/ProjNet.Tests/ProjNET.Tests.csproj
@@ -5,7 +5,7 @@
     <SignAssembly>true</SignAssembly>
     <NoWarn>1701;1702;1591</NoWarn>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net6;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,7 +16,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="$(SolutionDir)src\ProjNet\ProjNET.csproj" />
+    <ProjectReference Condition="'$(TargetFramework)' == 'net6.0'" Include="$(SolutionDir)src\ProjNet\ProjNET.csproj">
+      <SetTargetFramework>TargetFramework=netstandard2.0</SetTargetFramework>
+    </ProjectReference>
+    <ProjectReference Condition="'$(TargetFramework)' != 'net6.0'" Include="$(SolutionDir)src\ProjNet\ProjNET.csproj">
+      <SetTargetFramework>TargetFramework=net8.0</SetTargetFramework>
+    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/ProjNet.Tests/Serialization/BaseSerializationTest.cs
+++ b/test/ProjNet.Tests/Serialization/BaseSerializationTest.cs
@@ -1,24 +1,16 @@
-﻿using System.IO;
-using System.Runtime.Serialization;
-using System.Runtime.Serialization.Formatters.Binary;
+﻿using System;
+using Newtonsoft.Json;
 
 namespace ProjNET.Tests.Serialization
 {
     public class BaseSerializationTest
     {
-        public IFormatter GetFormatter()
+
+        public static T SanD<T>(T instance)
         {
-            return new BinaryFormatter();
+            string jsonData = JsonConvert.SerializeObject(instance);
+            return JsonConvert.DeserializeObject<T>(jsonData);
         }
 
-        public static T SanD<T>(T instance, IFormatter formatter)
-        {
-            using (var ms = new MemoryStream())
-            {
-                formatter.Serialize(ms, instance);
-                ms.Seek(0, SeekOrigin.Begin);
-                return (T)formatter.Deserialize(ms);
-            }
-        }
     }
 }

--- a/test/ProjNet.Tests/Serialization/CoordinateSystemsProjectionsTest.cs
+++ b/test/ProjNet.Tests/Serialization/CoordinateSystemsProjectionsTest.cs
@@ -6,7 +6,7 @@ namespace ProjNET.Tests.Serialization
     public class CoordinateSystemsProjectionsTest : BaseSerializationTest
     {
         [Test]
-        public void TestProjectionParameterSet() 
+        public void TestProjectionParameterSet()
         {
             var ps = new ProjNet.CoordinateSystems.Projections.ProjectionParameterSet(
                 new[]
@@ -16,7 +16,7 @@ namespace ProjNET.Tests.Serialization
                     }
                 );
 
-            var psD = SanD(ps, GetFormatter());
+            var psD = SanD(ps);
 
             Assert.AreEqual(ps, psD);
         }


### PR DESCRIPTION
Hi everyone,

Don't know if you are willing to upgrade? But if so I found some time to upgrade this ProjNET to newest dotnet versions.

The lib project now targets netstandard2.0 and net8.0.
The other 2 projects (Benchmark and UnitTests) target net6.0 and net8.0

Tested on Mac M3 in JetBrains Rider: Unit- and Benchmark tests are working.
Benchmark results:
```
// * Summary *

BenchmarkDotNet=v0.12.1, OS=macOS 14.5 (23F79) [Darwin 23.5.0]
Apple M3 Pro, 1 CPU, 12 logical and 12 physical cores
.NET Core SDK=8.0.302
  [Host]     : .NET Core 8.0.6 (CoreCLR 8.0.624.26715, CoreFX 8.0.624.26715), Arm64 RyuJIT
  DefaultJob : .NET Core 8.0.6 (CoreCLR 8.0.624.26715, CoreFX 8.0.624.26715), Arm64 RyuJIT


|            Method |     Mean |     Error |    StdDev |   Median |
|------------------ |---------:|----------:|----------:|---------:|
|       SoAOneByOne | 6.351 ms | 0.1039 ms | 0.0867 ms | 6.314 ms |
|        SoABatched | 5.611 ms | 0.0895 ms | 0.0837 ms | 5.573 ms |
|  TightAoSOneByOne | 6.324 ms | 0.1173 ms | 0.1097 ms | 6.420 ms |
|   TightAoSBatched | 5.324 ms | 0.0169 ms | 0.0141 ms | 5.326 ms |
| LooserAoSOneByOne | 6.423 ms | 0.0271 ms | 0.0212 ms | 6.428 ms |
|  LooserAoSBatched | 5.965 ms | 0.0445 ms | 0.0417 ms | 5.988 ms |

// * Hints *
Outliers
  PerformanceTests.SoAOneByOne: Default       -> 2 outliers were removed (6.63 ms, 6.63 ms)
  PerformanceTests.TightAoSBatched: Default   -> 2 outliers were removed (5.44 ms, 5.45 ms)
  PerformanceTests.LooserAoSOneByOne: Default -> 3 outliers were removed, 4 outliers were detected (6.36 ms, 6.58 ms..6.59 ms)

// * Legends *
  Mean   : Arithmetic mean of all measurements
  Error  : Half of 99.9% confidence interval
  StdDev : Standard deviation of all measurements
  Median : Value separating the higher half of all measurements (50th percentile)
  1 ms   : 1 Millisecond (0.001 sec)
```

Fixed some errors and warnings:
- ProjectionParameterSet now has default constructor for JSon serialization. The old one is obsolete now because of security issue(s) with IFormatter/BinaryFormatter.
- Warnings about missing XML comment(s) fixed