### PR TITLE
Fixed an error when reading the AuthorityCode parameter

### DIFF
--- a/src/ProjNet/IO/CoordinateSystems/CoordinateSystemWktReader.cs
+++ b/src/ProjNet/IO/CoordinateSystems/CoordinateSystemWktReader.cs
@@ -367,7 +367,7 @@ namespace ProjNet.IO.CoordinateSystems
             string authority = string.Empty;
             long authorityCode = -1;
 
-            tokenizer.NextToken();
+            var ct = tokenizer.NextToken();
             if (tokenizer.GetStringValue() == ",")
             {
                 tokenizer.NextToken();
@@ -377,11 +377,18 @@ namespace ProjNet.IO.CoordinateSystems
                     tokenizer.NextToken();
                     if (tokenizer.GetStringValue() == ",") tokenizer.NextToken();
                 }
-                if (tokenizer.GetStringValue() == ",") tokenizer.NextToken();
-                if (tokenizer.GetStringValue() == "AUTHORITY")
+
+                while (ct != TokenType.Eol && ct != TokenType.Eof)
                 {
-                    tokenizer.ReadAuthority(out authority, out authorityCode);
-                    tokenizer.ReadCloser(bracket);
+                    if (tokenizer.GetStringValue() == "AUTHORITY")
+                    {
+                        tokenizer.ReadAuthority(out authority, out authorityCode);
+                        break;
+                    }
+                    else
+                    {
+                        ct = tokenizer.NextToken();
+                    }
                 }
             }
             //This is default axis values if not specified.

--- a/test/ProjNet.Tests/ProjNetIssues.cs
+++ b/test/ProjNet.Tests/ProjNetIssues.cs
@@ -297,5 +297,22 @@ namespace ProjNET.Tests
             Assert.IsTrue(cmpdCs.HeadCoordinateSystem is ProjectedCoordinateSystem);
             Assert.IsTrue(cmpdCs.TailCoordinateSystem is VerticalCoordinateSystem);
         }
+
+        /// <summary>
+        /// Tests if a coordinate system can be created from a Well-Known Text (WKT) representation
+        /// and verifies that the authority code is correctly loaded.
+        /// </summary>
+        /// <remarks>
+        /// This test ensures that the WKT parsing functionality of the CoordinateSystemFactory
+        /// correctly initializes the coordinate system and its associated metadata, such as the authority code.
+        /// </remarks>
+        [Test]
+        public void TestAuthorityNotLoadedIssue()
+        {
+            string wkt = "PROJCS[\"WGS 84 / Pseudo-Mercator\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Mercator_1SP\"],PARAMETER[\"central_meridian\",0],PARAMETER[\"scale_factor\",1],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"X\",EAST],AXIS[\"Y\",NORTH],EXTENSION[\"PROJ4\",\"+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs\"],AUTHORITY[\"EPSG\",\"3857\"]]";
+            var coordinateSystem = CoordinateSystemFactory.CreateFromWkt(wkt);
+            Assert.IsNotNull(coordinateSystem);
+            Assert.AreEqual(coordinateSystem.AuthorityCode, 3857);
+        }
     }
 }


### PR DESCRIPTION
There was an error reading the AuthorityCode inside of the WKT. Also added a test for reading it properly